### PR TITLE
Fix clamp override in turning radius calc

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1515,7 +1515,6 @@ namespace BDArmory.Modules
             maxLiftAcceleration *= (float)vessel.dynamicPressurekPa;       //maximum acceleration from lift that the vehicle can provide
 
             maxLiftAcceleration = Math.Min(maxLiftAcceleration, maxAllowedGForce * 9.81f);       //limit it to whichever is smaller, what we can provide or what we can handle
-            maxLiftAcceleration = maxAllowedGForce * 9.81f;
 
             if (maxLiftAcceleration > 0)
                 turnRadius = (float)vessel.Velocity().sqrMagnitude / maxLiftAcceleration;     //radius that we can turn in assuming constant velocity, assuming simple circular motion


### PR DESCRIPTION
Problem: planes often drive straight into the ground.

Cause: turning radius calculation is being overridden with max-g
constraint leading to overestimation of available steering command
authority.

Solution: remove egregious override.