### PR TITLE
Add autospawn/respawn

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -56,6 +56,7 @@
         [BDAPersistantSettingsField] public static int MAX_FIRES_PER_VESSEL = 10;                   //controls fx for penetration only for landed or splashed
         [BDAPersistantSettingsField] public static float FIRELIFETIME_IN_SECONDS = 90f;             //controls fx for penetration only for landed or splashed
         [BDAPersistantSettingsField] public static bool PERFORMANCE_LOGGING = false;
+        [BDAPersistantSettingsField] public static bool SPAWN_VESSELS = true;
         [BDAPersistantSettingsField] public static bool AUTOCATEGORIZE_PARTS = true;
         [BDAPersistantSettingsField] public static bool SHOW_CATEGORIES = false;
     }

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Control\BDACompetitionMode.cs" />
     <Compile Include="UI\IBDWMModule.cs" />
     <Compile Include="UI\KrakensbaneDebug.cs" />
+    <Compile Include="UI\VesselSpawner.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BDArmory.Core\BDArmory.Core.csproj">

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1397,6 +1397,8 @@ namespace BDArmory.UI
             BDArmorySettings.BULLET_DECALS = GUI.Toggle(SLeftRect(line), BDArmorySettings.BULLET_DECALS, Localizer.Format("#LOC_BDArmory_Settings_BulletHoleDecals"));//"Bullet Hole Decals"
             BDArmorySettings.PERFORMANCE_LOGGING = GUI.Toggle(SRightRect(line), BDArmorySettings.PERFORMANCE_LOGGING, Localizer.Format("#LOC_BDArmory_Settings_PerformanceLogging"));//"Performance Logging"
             line++;
+            BDArmorySettings.SPAWN_VESSELS = GUI.Toggle(SRightRect(line), BDArmorySettings.SPAWN_VESSELS, "Auto Spawn Vessels");
+            line++;
             if (HighLogic.LoadedSceneIsEditor)
             {
                 if (BDArmorySettings.SHOW_CATEGORIES != (BDArmorySettings.SHOW_CATEGORIES = GUI.Toggle(SLeftRect(line), BDArmorySettings.SHOW_CATEGORIES, Localizer.Format("#LOC_BDArmory_Settings_ShowEditorSubcategories"))))//"Show Editor Subcategories"
@@ -1503,10 +1505,9 @@ namespace BDArmory.UI
 
                     if (GUI.Button(SRightRect(line), Localizer.Format("#LOC_BDArmory_Settings_StartCompetition")))//"Start Competition"
                     {
-
                         competitionDist = Mathf.Max(competitionDist, 0);
                         compDistGui = competitionDist.ToString();
-                        BDACompetitionMode.Instance.StartCompetitionMode(competitionDist);
+                        BDACompetitionMode.Instance.StartCompetitionMode(competitionDist, BDArmorySettings.SPAWN_VESSELS);
                         SaveConfig();
                         windowSettingsEnabled = false;
                     }

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -273,7 +273,6 @@ namespace BDArmory.UI
                                     {
                                         if (wm.Current == null) continue;
                                         allPilots.Add(wm.Current);
-
                                     }
 
                         foreach (var pilot in allPilots)

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -3,14 +3,10 @@ using System.Collections.Generic;
 using BDArmory.Misc;
 using BDArmory.Modules;
 using BDArmory.Control;
-using BDArmory.Core;
 using UnityEngine;
 using KSP.Localization;
-using BDArmory.FX;
-using Expansions;
 using System;
-using VehiclePhysics;
-using System.Net;
+using BDArmory.Core;
 
 namespace BDArmory.UI
 {
@@ -27,7 +23,7 @@ namespace BDArmory.UI
         private bool _ready;
         private bool _showGui;
         private static bool _teamSwitchDirty;
-        private bool _autoCameraSwitch = false;
+        private static bool _autoCameraSwitch = false;
 
         private readonly float _titleHeight = 30;
         private double lastCameraSwitch = 0;
@@ -36,16 +32,15 @@ namespace BDArmory.UI
         private Vessel lastActiveVessel = null;
         private float lastVesselScore = 100000;
         private float updateTimer = 0;
- 
 
         //gui params
         private float _windowHeight; //auto adjusting
-        private readonly float _windowWidth = 500;
+        private readonly float _windowWidth = 700;
 
         private SortedList<string, List<MissileFire>> weaponManagers = new SortedList<string, List<MissileFire>>();
         private Dictionary<string, float> cameraScores = new Dictionary<string, float>();
-       
-        
+
+
         private MissileFire _wmToSwitchTeam;
 
         // booleans to track state of buttons affecting everyone
@@ -61,9 +56,8 @@ namespace BDArmory.UI
 
         private static System.Random rng;
 
-        static  LoadedVesselSwitcher()
+        static LoadedVesselSwitcher()
         {
-
             redLight.normal.textColor = Color.red;
             yellowLight.normal.textColor = Color.yellow;
             greenLight.normal.textColor = Color.green;
@@ -151,7 +145,7 @@ namespace BDArmory.UI
                     if (_showGui && updateTimer < 0)
                     {
                         UpdateList();
-                        updateTimer = 0.5f;    //next update in half a sec only
+                        updateTimer = 0.5f; //next update in half a sec only
                     }
                 }
 
@@ -161,7 +155,7 @@ namespace BDArmory.UI
                 }
 
                 // check for camera changes
-                if(_autoCameraSwitch)
+                if (_autoCameraSwitch)
                 {
                     UpdateCamera();
                 }
@@ -198,6 +192,7 @@ namespace BDArmory.UI
                             break;
                         }
             }
+
             v.Dispose();
         }
 
@@ -230,13 +225,14 @@ namespace BDArmory.UI
                             {
                                 wm.Current.AI.ActivatePilot();
                                 BDArmory.Misc.Misc.fireNextNonEmptyStage(wm.Current.vessel);
-                            } else
+                            }
+                            else
                             {
                                 wm.Current.AI.DeactivatePilot();
                             }
                         }
         }
-    
+
 
         private void OnGUI()
         {
@@ -247,7 +243,7 @@ namespace BDArmory.UI
                     SetNewHeight(_windowHeight);
                     // this Rect initialization ensures any save issues with height or width of the window are resolved
                     BDArmorySetup.WindowRectVesselSwitcher = new Rect(BDArmorySetup.WindowRectVesselSwitcher.x, BDArmorySetup.WindowRectVesselSwitcher.y, _windowWidth, _windowHeight);
-                    BDArmorySetup.WindowRectVesselSwitcher = GUI.Window(10293444, BDArmorySetup.WindowRectVesselSwitcher, WindowVesselSwitcher, Localizer.Format("#LOC_BDArmory_BDAVesselSwitcher_Title"),//"BDA Vessel Switcher"
+                    BDArmorySetup.WindowRectVesselSwitcher = GUI.Window(10293444, BDArmorySetup.WindowRectVesselSwitcher, WindowVesselSwitcher, Localizer.Format("#LOC_BDArmory_BDAVesselSwitcher_Title"), //"BDA Vessel Switcher"
                         BDArmorySetup.BDGuiSkin.window);
                     Misc.Misc.UpdateGUIRect(BDArmorySetup.WindowRectVesselSwitcher, _guiCheckIndex);
                 }
@@ -258,7 +254,7 @@ namespace BDArmory.UI
 
                 if (_teamSwitchDirty)
                 {
-                   
+
                     if (_wmToSwitchTeam)
                         _wmToSwitchTeam.NextTeam();
                     else
@@ -266,7 +262,7 @@ namespace BDArmory.UI
                         // if no team is specified toggle between FFA and all friends
                         // FFA button starts timer running
                         //ResetSpeeds();
-                        _freeForAll = ! _freeForAll;
+                        _freeForAll = !_freeForAll;
                         char T = 'A';
                         // switch everyone to their own teams
                         var allPilots = new List<MissileFire>();
@@ -279,16 +275,18 @@ namespace BDArmory.UI
                                         allPilots.Add(wm.Current);
 
                                     }
-                        foreach(var pilot in allPilots)
+
+                        foreach (var pilot in allPilots)
                         {
                             Debug.Log("[BDArmory] assigning " + pilot.vessel.GetDisplayName() + " to team " + T.ToString());
                             pilot.SetTeam(BDTeam.Get(T.ToString()));
-                            if(_freeForAll) T++;
+                            if (_freeForAll) T++;
                         }
                     }
+
                     _teamSwitchDirty = false;
                     _wmToSwitchTeam = null;
-                } 
+                }
             }
         }
 
@@ -299,7 +297,7 @@ namespace BDArmory.UI
 
         private void WindowVesselSwitcher(int id)
         {
-            GUI.DragWindow(new Rect(0, 0, _windowWidth - 6* (_buttonHeight)- _margin, _titleHeight));
+            GUI.DragWindow(new Rect(0, 0, _windowWidth - 6 * (_buttonHeight) - _margin, _titleHeight));
 
             if (GUI.Button(new Rect(_windowWidth - 6 * (_buttonHeight) - _margin, 4, _buttonHeight, _buttonHeight), "M", BDACompetitionMode.Instance.killerGMenabled ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button))
             {
@@ -377,29 +375,41 @@ namespace BDArmory.UI
                                 incomingThreat = true;
                                 targetName = "<<<" + wm.Current.incomingThreatVessel.GetName();
                                 targetVessel = wm.Current.incomingThreatVessel;
-                            }else if (wm.Current.currentTarget)
+                            }
+                            else if (wm.Current.currentTarget)
                             {
                                 targetName = ">>>" + wm.Current.currentTarget.Vessel.GetName();
                                 targetVessel = wm.Current.currentTarget.Vessel;
-                            }                  
+                            }
 
                             string status = UpdateVesselStatus(wm.Current, vButtonStyle);
-                            int currentScore = 0;
-                            
                             string vesselName = wm.Current.vessel.GetName();
 
-                            BDArmory.Control.ScoringData scoreData = null; 
+                            var postStatus = " ";
+                            ScoringData scoreData = null;
                             if (BDACompetitionMode.Instance.Scores.ContainsKey(vesselName))
                             {
                                 scoreData = BDACompetitionMode.Instance.Scores[vesselName];
-                                currentScore = scoreData.Score;
+                                
+                                if (BDArmorySettings.SPAWN_VESSELS)
+                                {
+                                    postStatus += $"(H:{scoreData.Score} D:{scoreData.deaths} K:{scoreData.kills}|{scoreData.cleanKills})";
+                                }
+                                else
+                                {
+                                    postStatus += $"({scoreData.Score})";
+                                }
                             }
-                            string postStatus = " (" + currentScore.ToString() + ")";
+                            else
+                            {
+                                postStatus += "(0)";
+                            }
 
                             if (wm.Current.AI != null && wm.Current.AI.currentStatus != null)
                             {
                                 postStatus += " " + wm.Current.AI.currentStatus;
                             }
+
                             float targetDistance = 5000;
                             if (wm.Current.currentTarget != null)
                             {
@@ -412,17 +422,17 @@ namespace BDArmory.UI
                             //{
                             //    postStatus += " " + (BDACompetitionMode.Instance.FireCount[vesselName] + BDACompetitionMode.Instance.FireCount2[vesselName]).ToString() + ":" + Convert.ToInt32(BDACompetitionMode.Instance.AverageSpeed[vesselName] / BDACompetitionMode.Instance.averageCount).ToString();
                             //}
-                            
-                            if(BDACompetitionMode.Instance.KillTimer.ContainsKey(vesselName))
+
+                            if (BDACompetitionMode.Instance.KillTimer.ContainsKey(vesselName))
                             {
                                 postStatus += " x" + BDACompetitionMode.Instance.KillTimer[vesselName].ToString() + "x";
                             }
 
-                            if(targetName != "")
+                            if (targetName != "")
                             {
                                 postStatus += " " + targetName;
                             }
-                            
+
                             /*if (cameraScores.ContainsKey(vesselName))
                             {
                                 int sc = (int)(cameraScores[vesselName]);
@@ -439,47 +449,53 @@ namespace BDArmory.UI
                                 Rect targettingButtonRect = new Rect(_margin + vesselButtonWidth + _buttonHeight, height,
                                     _buttonHeight, _buttonHeight);
                                 GUIStyle targButton = BDArmorySetup.BDGuiSkin.button;
-                                if(wm.Current.currentGun != null && wm.Current.currentGun.recentlyFiring)
+                                if (wm.Current.currentGun != null && wm.Current.currentGun.recentlyFiring)
                                 {
-                                    if(targetDistance < 500)
+                                    if (targetDistance < 500)
                                     {
                                         targButton = redLight;
-                                    } else if(targetDistance < 1000)
+                                    }
+                                    else if (targetDistance < 1000)
                                     {
                                         targButton = yellowLight;
-                                    } else
+                                    }
+                                    else
                                     {
                                         targButton = blueLight;
                                     }
                                 }
+
                                 if (GUI.Button(targettingButtonRect, incomingThreat ? "><" : "[]", targButton))
                                     ForceSwitchVessel(targetVessel);
                             }
 
                             //guard toggle
                             GUIStyle guardStyle = wm.Current.guardMode ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
-                            Rect guardButtonRect = new Rect(_margin + vesselButtonWidth + 2 *_buttonHeight, height, _buttonHeight, _buttonHeight);
+                            Rect guardButtonRect = new Rect(_margin + vesselButtonWidth + 2 * _buttonHeight, height, _buttonHeight, _buttonHeight);
                             if (GUI.Button(guardButtonRect, "G", guardStyle))
                                 wm.Current.ToggleGuardMode();
 
                             //AI toggle
                             if (wm.Current.AI != null)
                             {
-                                GUIStyle aiStyle = new GUIStyle( wm.Current.AI.pilotEnabled ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button);
-                                if(wm.Current.underFire)
+                                GUIStyle aiStyle = new GUIStyle(wm.Current.AI.pilotEnabled ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button);
+                                if (wm.Current.underFire)
                                 {
                                     var distance = Vector3.Distance(wm.Current.vessel.GetWorldPos3D(), wm.Current.incomingThreatPosition);
-                                    if(distance < 500)
+                                    if (distance < 500)
                                     {
                                         aiStyle.normal.textColor = Color.red;
-                                    } else if(distance < 1000)
+                                    }
+                                    else if (distance < 1000)
                                     {
                                         aiStyle.normal.textColor = Color.yellow;
-                                    } else
+                                    }
+                                    else
                                     {
                                         aiStyle.normal.textColor = Color.blue;
                                     }
                                 }
+
                                 Rect aiButtonRect = new Rect(_margin + vesselButtonWidth + 3 * _buttonHeight, height, _buttonHeight,
                                     _buttonHeight);
                                 if (GUI.Button(aiButtonRect, "P", aiStyle))
@@ -487,7 +503,7 @@ namespace BDArmory.UI
                             }
 
                             //team toggle
-                            Rect teamButtonRect = new Rect(_margin + vesselButtonWidth + 4*_buttonHeight, height,
+                            Rect teamButtonRect = new Rect(_margin + vesselButtonWidth + 4 * _buttonHeight, height,
                                 _buttonHeight, _buttonHeight);
                             if (GUI.Button(teamButtonRect, "T", BDArmorySetup.BDGuiSkin.button))
                             {
@@ -502,14 +518,14 @@ namespace BDArmory.UI
                                 }
                             }
 
-                                    
+
                             // boom
-                            Rect killButtonRect = new Rect(_margin + vesselButtonWidth + 5 * _buttonHeight , height, _buttonHeight, _buttonHeight);
+                            Rect killButtonRect = new Rect(_margin + vesselButtonWidth + 5 * _buttonHeight, height, _buttonHeight, _buttonHeight);
                             GUIStyle xStyle = new GUIStyle(BDArmorySetup.BDGuiSkin.button);
                             var currentParts = wm.Current.vessel.parts.Count;
-                            if(scoreData != null)
+                            if (scoreData != null)
                             {
-                                if(currentParts < scoreData.previousPartCount)
+                                if (currentParts < scoreData.previousPartCount)
                                 {
                                     xStyle.normal.textColor = Color.red;
                                 }
@@ -518,43 +534,55 @@ namespace BDArmory.UI
                                     xStyle.normal.textColor = Color.yellow;
                                 }
                             }
+
                             if (GUI.Button(killButtonRect, "X", xStyle))
                             {
                                 // must use right button
                                 if (Event.current.button == 1)
                                 {
-                                    if (scoreData.lastPersonWhoHitMe == "") {
+                                    if (scoreData.lastPersonWhoHitMe == "")
+                                    {
                                         scoreData.lastPersonWhoHitMe = "BIG RED BUTTON"; // only do this if it's not already damaged
                                     }
+
                                     Misc.Misc.ForceDeadVessel(wm.Current.vessel);
                                 }
                             }
+
                             height += _buttonHeight + _buttonGap;
                         }
                 }
-        
-            height += _margin;
-            // add all the lost pilots at the bottom
-            foreach (string key in BDACompetitionMode.Instance.DeathOrder.Keys)
-            {
-                string postString = "";
-                if (BDACompetitionMode.Instance.Scores.ContainsKey(key))
-                {
 
-                    postString = " KILLED BY " + BDACompetitionMode.Instance.Scores[key].lastPersonWhoHitMe;
+            height += _margin;
+
+            if (!BDArmorySettings.SPAWN_VESSELS)
+            {
+                // add all the lost pilots at the bottom
+                foreach (string key in BDACompetitionMode.Instance.DeathOrder.Keys)
+                {
+                    string postString = "";
+                    if (BDACompetitionMode.Instance.Scores.ContainsKey(key))
+                    {
+
+                        postString = " KILLED BY " + BDACompetitionMode.Instance.Scores[key].lastPersonWhoHitMe;
+                    }
+
+                    GUI.Label(new Rect(_margin, height, vesselButtonWidth, _buttonHeight), "DEAD " + BDACompetitionMode.Instance.DeathOrder[key] + " : " + key + " (" + BDACompetitionMode.Instance.Scores[key].Score.ToString() + ")" + postString, BDArmorySetup.BDGuiSkin.label);
+                    height += _buttonHeight + _buttonGap;
                 }
-                GUI.Label(new Rect(_margin, height, vesselButtonWidth, _buttonHeight), "DEAD " + BDACompetitionMode.Instance.DeathOrder[key] + " : " + key + " (" + BDACompetitionMode.Instance.Scores[key].Score.ToString() + ")" + postString, BDArmorySetup.BDGuiSkin.label);
-                height += _buttonHeight + _buttonGap;
             }
-            if(!BDACompetitionMode.Instance.pinataAlive)
+
+            if (!BDACompetitionMode.Instance.pinataAlive)
             {
                 string postString = "";
-                foreach(var killer in BDACompetitionMode.Instance.Scores.Keys) {
-                    if(BDACompetitionMode.Instance.Scores[killer].PinataHits > 0)
+                foreach (var killer in BDACompetitionMode.Instance.Scores.Keys)
+                {
+                    if (BDACompetitionMode.Instance.Scores[killer].PinataHits > 0)
                     {
                         postString += " " + killer;
                     }
                 }
+
                 if (postString != "")
                 {
                     GUI.Label(new Rect(_margin, height, vesselButtonWidth, _buttonHeight), "PInata Killers: " + postString, BDArmorySetup.BDGuiSkin.label);
@@ -573,19 +601,18 @@ namespace BDArmory.UI
             if (wm.vessel.LandedOrSplashed)
             {
                 if (wm.vessel.Landed)
-                    status = Localizer.Format("#LOC_BDArmory_VesselStatus_Landed");//"(Landed)"
+                    status = Localizer.Format("#LOC_BDArmory_VesselStatus_Landed"); //"(Landed)"
                 else
-                    status = Localizer.Format("#LOC_BDArmory_VesselStatus_Splashed");//"(Splashed)"
+                    status = Localizer.Format("#LOC_BDArmory_VesselStatus_Splashed"); //"(Splashed)"
                 vButtonStyle.fontStyle = FontStyle.Italic;
             }
             else
             {
                 vButtonStyle.fontStyle = FontStyle.Normal;
             }
+
             return status;
         }
-
-        
 
         private void SwitchToNextVessel()
         {
@@ -606,9 +633,15 @@ namespace BDArmory.UI
                                 return;
                             }
                         }
+
             var firstVessel = weaponManagers.Values[0][0].vessel;
             if (!firstVessel.isActiveVessel)
                 ForceSwitchVessel(firstVessel);
+        }
+
+        public static void AutoCameraSwitch(bool on = true)
+        {
+            _autoCameraSwitch = on;
         }
 
         public static void MassTeamSwitch()
@@ -632,8 +665,10 @@ namespace BDArmory.UI
                                 ForceSwitchVessel(previousVessel);
                                 return;
                             }
+
                             previousVessel = wm.Current.vessel;
                         }
+
             if (!previousVessel.isActiveVessel)
                 ForceSwitchVessel(previousVessel);
         }
@@ -658,6 +693,7 @@ namespace BDArmory.UI
                         lostActiveVessel = false;
                     }
                 }
+
                 lastActiveVessel = FlightGlobals.ActiveVessel;
                 double timeSinceChange = Planetarium.GetUniversalTime() - lastCameraSwitch;
 
@@ -676,7 +712,7 @@ namespace BDArmory.UI
                             if (wms.Current != null && wms.Current.vessel != null)
                             {
                                 float vesselScore = 1000;
-                                float targetDistance = 5000 + (float)(rng.NextDouble() * 100.0);
+                                float targetDistance = 5000 + (float) (rng.NextDouble() * 100.0);
                                 float crashTime = 30;
                                 string vesselName = v.Current.GetName();
                                 // avoid lingering on dying things
@@ -684,7 +720,7 @@ namespace BDArmory.UI
                                 bool recentlyLanded = false;
 
                                 // check for damage & landed status
-                                
+
                                 if (BDACompetitionMode.Instance.Scores.ContainsKey(vesselName))
                                 {
                                     var currentParts = v.Current.parts.Count;
@@ -703,21 +739,25 @@ namespace BDArmory.UI
                                         }
                                     }
                                 }
+
                                 vesselScore = Math.Abs(vesselScore);
 
                                 if (!recentlyLanded && v.Current.verticalSpeed < -5)
                                 {
-                                    crashTime = (float)(- Math.Abs(v.Current.radarAltitude) / v.Current.verticalSpeed);
+                                    crashTime = (float) (-Math.Abs(v.Current.radarAltitude) / v.Current.verticalSpeed);
                                 }
+
                                 if (wms.Current.currentTarget != null)
                                 {
                                     targetDistance = Vector3.Distance(wms.Current.vessel.GetWorldPos3D(), wms.Current.currentTarget.position);
                                 }
+
                                 vesselScore *= targetDistance / 1000;
-                                if(crashTime < 30)
+                                if (crashTime < 30)
                                 {
                                     vesselScore *= crashTime / 30;
                                 }
+
                                 if (wms.Current.currentGun != null)
                                 {
                                     if (wms.Current.currentGun.recentlyFiring)
@@ -726,6 +766,7 @@ namespace BDArmory.UI
                                         vesselScore *= 0.25f;
                                     }
                                 }
+
                                 // scoring for automagic camera check should not be in here
                                 if (wms.Current.underAttack || wms.Current.underFire)
                                 {
@@ -741,22 +782,26 @@ namespace BDArmory.UI
                                         }
                                     }
 
-                                } else if(wms.Current.isFlaring)
+                                }
+                                else if (wms.Current.isFlaring)
                                 {
                                     vesselScore *= 0.5f;
                                 }
-                                if(recentlyDamaged)
+
+                                if (recentlyDamaged)
                                 {
                                     vesselScore *= 0.3f; // because taking hits is very interesting;
                                 }
-                                if(!recentlyLanded && wms.Current.vessel.LandedOrSplashed)
+
+                                if (!recentlyLanded && wms.Current.vessel.LandedOrSplashed)
                                 {
                                     vesselScore *= 3; // not interesting.
                                 }
+
                                 // if we're the active vessel add a penalty over time to force it to switch away eventually
                                 if (wms.Current.vessel.isActiveVessel)
                                 {
-                                    vesselScore = (float)(vesselScore * timeSinceChange /8.0);
+                                    vesselScore = (float) (vesselScore * timeSinceChange / 8.0);
                                     foundActiveVessel = true;
                                 }
 
@@ -767,25 +812,30 @@ namespace BDArmory.UI
                                     bestVessel = wms.Current.vessel;
                                     bestScore = vesselScore;
                                 }
+
                                 cameraScores[wms.Current.vessel.GetName()] = vesselScore;
                             }
                 }
-                if(!foundActiveVessel)
+
+                if (!foundActiveVessel)
                 {
-                    if (!lostActiveVessel) {
+                    if (!lostActiveVessel)
+                    {
                         // the active vessel is no longer in our list, so it probably just got shot
                         // we need to make sure we follow it for a few seconds
                         lastCameraSwitch = Planetarium.GetUniversalTime();
                         lostActiveVessel = true;
-                    } else
+                    }
+                    else
                     {
                         var score = 100 * timeSinceChange;
-                        if(score < bestScore)
+                        if (score < bestScore)
                         {
                             bestVessel = null; // stop switching
                         }
                     }
                 }
+
                 if (timeSinceChange > 3)
                 {
                     if (bestVessel != null && !(bestVessel.isActiveVessel)) // if a vessel dies it'll use a default score for a few seconds
@@ -796,8 +846,6 @@ namespace BDArmory.UI
                 }
             }
         }
-                
-
 
         // Extracted method, so we dont have to call these two lines everywhere
         private void ForceSwitchVessel(Vessel v)

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using KSP.UI.Screens;
+using UnityEngine;
+
+namespace BDArmory.UI
+{
+	[KSPAddon(KSPAddon.Startup.Flight, false)]
+	public class VesselSpawner : MonoBehaviour
+	{
+		public static VesselSpawner Instance;
+
+		void Awake()
+		{
+			if (Instance)
+			{
+				Destroy(Instance);
+			}
+
+			Instance = this;
+		}
+
+		private void OnGUI()
+		{
+		}
+
+		// THE FOLLOWING STOLEN FROM VESSEL MOVER	
+		public Vessel SpawnVesselFromCraftFile(string craftURL, Vector3d gpsCoords, float heading, float pitch, List<ProtoCrewMember> crewData = null)
+		{
+			VesselData newData = new VesselData();
+
+			newData.craftURL = craftURL;
+			newData.latitude = gpsCoords.x;
+			newData.longitude = gpsCoords.y;
+			newData.altitude = gpsCoords.z + 35;
+
+			newData.body = FlightGlobals.currentMainBody;
+			newData.heading = heading;
+			newData.pitch = pitch;
+			newData.orbiting = false;
+			newData.flagURL = HighLogic.CurrentGame.flagURL;
+			newData.owned = true;
+			newData.vesselType = VesselType.Ship;
+
+			newData.crew = new List<CrewData>();
+
+			return SpawnVessel(newData, crewData);
+		}
+
+		private Vessel SpawnVessel(VesselData vesselData, List<ProtoCrewMember> crewData = null)
+		{
+			string gameDataDir = KSPUtil.ApplicationRootPath;
+			Debug.Log("Spawning a vessel named '" + vesselData.name + "'");
+
+			// Set additional info for landed vessels
+			bool landed = false;
+			if (!vesselData.orbiting)
+			{
+				landed = true;
+				if (vesselData.altitude == null || vesselData.altitude < 0)
+				{
+					vesselData.altitude = 35;//LocationUtil.TerrainHeight(vesselData.latitude, vesselData.longitude, vesselData.body);
+				}
+
+				Vector3d pos = vesselData.body.GetRelSurfacePosition(vesselData.latitude, vesselData.longitude, vesselData.altitude.Value);
+
+				vesselData.orbit = new Orbit(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, vesselData.body);
+				vesselData.orbit.UpdateFromStateVectors(pos, vesselData.body.getRFrmVel(pos), vesselData.body, Planetarium.GetUniversalTime());
+			}
+			else
+			{
+				vesselData.orbit.referenceBody = vesselData.body;
+			}
+
+			ConfigNode[] partNodes;
+			//UntrackedObjectClass sizeClass;
+			ShipConstruct shipConstruct = null;
+			bool hasClamp = false;
+			float lcHeight = 0;
+			ConfigNode craftNode;
+			Quaternion craftRotation = Quaternion.identity;
+			if (!string.IsNullOrEmpty(vesselData.craftURL))
+			{
+				// Save the current ShipConstruction ship, otherwise the player will see the spawned ship next time they enter the VAB!
+				ConfigNode currentShip = ShipConstruction.ShipConfig;
+
+				shipConstruct = ShipConstruction.LoadShip(vesselData.craftURL);
+				if (shipConstruct == null)
+				{
+					Debug.Log("ShipConstruct was null when tried to load '" + vesselData.craftURL +
+					          "' (usually this means the file could not be found).");
+					return null;
+				}
+
+				craftNode = ConfigNode.Load(vesselData.craftURL);
+				lcHeight = ConfigNode.ParseVector3(craftNode.GetNode("PART").GetValue("pos")).y;
+				craftRotation = ConfigNode.ParseQuaternion(craftNode.GetNode("PART").GetValue("rot"));
+
+				// Restore ShipConstruction ship
+				ShipConstruction.ShipConfig = currentShip;
+
+				// Set the name
+				if (string.IsNullOrEmpty(vesselData.name))
+				{
+					vesselData.name = shipConstruct.shipName;
+				}
+            
+				// Set some parameters that need to be at the part level
+				uint missionID = (uint)Guid.NewGuid().GetHashCode();
+				uint launchID = HighLogic.CurrentGame.launchID++;
+				foreach (Part p in shipConstruct.parts)
+				{
+					p.flightID = ShipConstruction.GetUniqueFlightID(HighLogic.CurrentGame.flightState);
+					p.missionID = missionID;
+					p.launchID = launchID;
+					p.flagURL = vesselData.flagURL ?? HighLogic.CurrentGame.flagURL;
+
+					// Had some issues with this being set to -1 for some ships - can't figure out
+					// why.  End result is the vessel exploding, so let's just set it to a positive
+					// value.
+					p.temperature = 1.0;
+				}
+            
+				//add minimal crew
+				//bool success = false;
+				Part part = shipConstruct.parts.Find(p => p.protoModuleCrew.Count < p.CrewCapacity);
+
+				// Add the crew member
+				if (part != null)
+				{
+					// Create the ProtoCrewMember
+					ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.GetNewKerbal();
+					crewMember.gender = UnityEngine.Random.Range(0, 100) > 50
+						? ProtoCrewMember.Gender.Female
+						: ProtoCrewMember.Gender.Male;
+					//crewMember.trait = "Pilot";
+
+					// Add them to the part
+					part.AddCrewmemberAt(crewMember, part.protoModuleCrew.Count);
+				}
+
+				// Create a dummy ProtoVessel, we will use this to dump the parts to a config node.
+				// We can't use the config nodes from the .craft file, because they are in a
+				// slightly different format than those required for a ProtoVessel (seriously
+				// Squad?!?).
+				ConfigNode empty = new ConfigNode();
+				ProtoVessel dummyProto = new ProtoVessel(empty, null);
+				Vessel dummyVessel = new Vessel();
+				dummyVessel.parts = shipConstruct.Parts;
+				dummyProto.vesselRef = dummyVessel;
+
+				// Create the ProtoPartSnapshot objects and then initialize them
+				foreach (Part p in shipConstruct.parts)
+				{
+					dummyVessel.loaded = false;
+					p.vessel = dummyVessel;
+
+					dummyProto.protoPartSnapshots.Add(new ProtoPartSnapshot(p, dummyProto,true));
+				}
+				foreach (ProtoPartSnapshot p in dummyProto.protoPartSnapshots)
+				{
+					p.storePartRefs();
+				}
+
+				// Create the ship's parts
+				List<ConfigNode> partNodesL = new List<ConfigNode>();
+				foreach (ProtoPartSnapshot snapShot in dummyProto.protoPartSnapshots)
+				{
+					ConfigNode node = new ConfigNode("PART");
+					snapShot.Save(node);
+					partNodesL.Add(node);
+				}
+				partNodes = partNodesL.ToArray();
+			}
+			else
+			{
+				// Create crew member array
+				ProtoCrewMember[] crewArray = new ProtoCrewMember[vesselData.crew.Count];
+				int i = 0;
+				foreach (CrewData cd in vesselData.crew)
+				{
+					// Create the ProtoCrewMember
+					ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.GetNewKerbal(ProtoCrewMember.KerbalType.Crew);
+					if (cd.name != null)
+					{
+						crewMember.KerbalRef.name = cd.name;
+					}
+
+					crewArray[i++] = crewMember;
+				}
+
+				// Create part nodes
+				uint flightId = ShipConstruction.GetUniqueFlightID(HighLogic.CurrentGame.flightState);
+				partNodes = new ConfigNode[1];
+				partNodes[0] = ProtoVessel.CreatePartNode(vesselData.craftPart.name, flightId, crewArray);
+
+				// Default the size class
+				//sizeClass = UntrackedObjectClass.A;
+
+				// Set the name
+				if (string.IsNullOrEmpty(vesselData.name))
+				{
+					vesselData.name = vesselData.craftPart.name;
+				}
+			}
+
+			// Create additional nodes
+			ConfigNode[] additionalNodes = new ConfigNode[0];
+
+			// Create the config node representation of the ProtoVessel
+			ConfigNode protoVesselNode = ProtoVessel.CreateVesselNode(vesselData.name, vesselData.vesselType, vesselData.orbit, 0, partNodes, additionalNodes);
+
+			// Additional seetings for a landed vessel
+			if (!vesselData.orbiting)
+			{
+				Vector3d norm = vesselData.body.GetRelSurfaceNVector(vesselData.latitude, vesselData.longitude);
+
+				double terrainHeight = 0.0;
+				if (vesselData.body.pqsController != null)
+				{
+					terrainHeight = vesselData.body.pqsController.GetSurfaceHeight(norm) - vesselData.body.pqsController.radius;
+				}
+				bool splashed = false;// = landed && terrainHeight < 0.001;
+
+				// Create the config node representation of the ProtoVessel
+				// Note - flying is experimental, and so far doesn't work
+				protoVesselNode.SetValue("sit", (splashed ? Vessel.Situations.SPLASHED : landed ?
+					Vessel.Situations.LANDED : Vessel.Situations.FLYING).ToString());
+				protoVesselNode.SetValue("landed", (landed && !splashed).ToString());
+				protoVesselNode.SetValue("splashed", splashed.ToString());
+				protoVesselNode.SetValue("lat", vesselData.latitude.ToString());
+				protoVesselNode.SetValue("lon", vesselData.longitude.ToString());
+				protoVesselNode.SetValue("alt", vesselData.altitude.ToString());
+				protoVesselNode.SetValue("landedAt", vesselData.body.name);
+
+				// Figure out the additional height to subtract
+				float lowest = float.MaxValue;
+				if (shipConstruct != null)
+				{
+					foreach (Part p in shipConstruct.parts)
+					{
+						foreach (Collider collider in p.GetComponentsInChildren<Collider>())
+						{
+							if (collider.gameObject.layer != 21 && collider.enabled)
+							{
+								lowest = Mathf.Min(lowest, collider.bounds.min.y);
+							}
+						}
+					}
+				}
+				else
+				{
+					foreach (Collider collider in vesselData.craftPart.partPrefab.GetComponentsInChildren<Collider>())
+					{
+						if (collider.gameObject.layer != 21 && collider.enabled)
+						{
+							lowest = Mathf.Min(lowest, collider.bounds.min.y);
+						}
+					}
+				}
+
+				if (lowest == float.MaxValue)
+				{
+					lowest = 0;
+				}
+
+				// Figure out the surface height and rotation
+				Quaternion normal = Quaternion.LookRotation((Vector3)norm);// new Vector3((float)norm.x, (float)norm.y, (float)norm.z));
+				Quaternion rotation = Quaternion.identity;
+				float heading = vesselData.heading;
+				if (shipConstruct == null)
+				{
+					rotation = rotation * Quaternion.FromToRotation(Vector3.up, Vector3.back);
+				}
+				else if (shipConstruct.shipFacility == EditorFacility.SPH)
+				{
+					rotation = rotation * Quaternion.FromToRotation(Vector3.forward, -Vector3.forward);
+					heading += 180.0f;
+				}
+				else
+				{
+					rotation = rotation * Quaternion.FromToRotation(Vector3.up, Vector3.forward);
+					rotation = Quaternion.FromToRotation(Vector3.up, -Vector3.up) * rotation;
+
+					vesselData.heading = 0;
+					vesselData.pitch = 0;
+				}
+
+				rotation = rotation * Quaternion.AngleAxis(heading, Vector3.back);
+				rotation = rotation * Quaternion.AngleAxis(vesselData.roll, Vector3.down);
+				rotation = rotation * Quaternion.AngleAxis(vesselData.pitch, Vector3.left);
+
+				// Set the height and rotation
+				if (landed || splashed)
+				{
+					float hgt = (shipConstruct != null ? shipConstruct.parts[0] : vesselData.craftPart.partPrefab).localRoot.attPos0.y - lowest;
+					hgt += vesselData.height;
+
+					foreach (Part p in shipConstruct.Parts)
+					{
+						LaunchClamp lc = p.FindModuleImplementing<LaunchClamp>();
+						if (lc)
+						{
+							hasClamp = true;
+							break;
+						}
+					}
+
+					if (!hasClamp)
+					{
+						hgt += 35;
+					}
+					else
+					{
+						hgt += lcHeight;
+					}
+					protoVesselNode.SetValue("hgt", hgt.ToString(), true);
+				}
+				protoVesselNode.SetValue("rot", KSPUtil.WriteQuaternion(normal * rotation), true);
+
+				// Set the normal vector relative to the surface
+				Vector3 nrm = (rotation * Vector3.forward);
+				protoVesselNode.SetValue("nrm", nrm.x + "," + nrm.y + "," + nrm.z, true);
+
+				protoVesselNode.SetValue("prst", false.ToString(), true);
+			}
+
+			// Add vessel to the game
+			ProtoVessel protoVessel = HighLogic.CurrentGame.AddVessel(protoVesselNode);
+          
+			// Store the id for later use
+			vesselData.id = protoVessel.vesselRef.id;
+			StartCoroutine(PlaceSpawnedVessel(protoVessel.vesselRef));
+          
+			//destroy prefabs
+			foreach (Part p in FindObjectsOfType<Part>())
+			{
+				if (!p.vessel)
+				{
+					Destroy(p.gameObject);
+				}
+			}
+
+			return protoVessel.vesselRef;
+		}
+
+		private IEnumerator PlaceSpawnedVessel(Vessel v)
+		{
+			v.isPersistent = true;
+			v.Landed = false;
+			v.situation = Vessel.Situations.FLYING;
+			while (v.packed)
+			{
+				yield return null;
+			}
+			v.SetWorldVelocity(Vector3d.zero);
+
+			yield return null;
+			FlightGlobals.ForceSetActiveVessel(v);
+			yield return null;
+			v.Landed = true;
+			v.situation = Vessel.Situations.PRELAUNCH;
+			v.GoOffRails();
+			v.IgnoreGForces(240);
+
+			//Staging.beginFlight();
+			StageManager.BeginFlight();
+		}
+
+		internal class CrewData
+		{
+			public string name = null;
+			public ProtoCrewMember.Gender? gender = null;
+			public bool addToRoster = true;
+
+			public CrewData() { }
+			public CrewData(CrewData cd)
+			{
+				name = cd.name;
+				gender = cd.gender;
+				addToRoster = cd.addToRoster;
+			}
+		}
+		private class VesselData
+		{
+			public string name = null;
+			public Guid? id = null;
+			public string craftURL = null;
+			public AvailablePart craftPart = null;
+			public string flagURL = null;
+			public VesselType vesselType = VesselType.Ship;
+			public CelestialBody body = null;
+			public Orbit orbit = null;
+			public double latitude = 0.0;
+			public double longitude = 0.0;
+			public double? altitude = null;
+			public float height = 0.0f;
+			public bool orbiting = false;
+			public bool owned = false;
+			public List<CrewData> crew = new List<CrewData>();
+			public PQSCity pqsCity = null;
+			public Vector3d pqsOffset;
+			public float heading;
+			public float pitch;
+			public float roll;
+		}
+	}
+}

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -50,10 +50,9 @@ namespace BDArmory.UI
 
 		private Vessel SpawnVessel(VesselData vesselData, List<ProtoCrewMember> crewData = null)
 		{
-			string gameDataDir = KSPUtil.ApplicationRootPath;
 			Debug.Log("Spawning a vessel named '" + vesselData.name + "'");
 
-			// Set additional info for landed vessels
+			//Set additional info for landed vessels
 			bool landed = false;
 			if (!vesselData.orbiting)
 			{
@@ -62,9 +61,9 @@ namespace BDArmory.UI
 				{
 					vesselData.altitude = 35;//LocationUtil.TerrainHeight(vesselData.latitude, vesselData.longitude, vesselData.body);
 				}
-
+			
 				Vector3d pos = vesselData.body.GetRelSurfacePosition(vesselData.latitude, vesselData.longitude, vesselData.altitude.Value);
-
+			
 				vesselData.orbit = new Orbit(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, vesselData.body);
 				vesselData.orbit.UpdateFromStateVectors(pos, vesselData.body.getRFrmVel(pos), vesselData.body, Planetarium.GetUniversalTime());
 			}


### PR DESCRIPTION
Sort of a work in progress, but worked well when testing 5 planes. Regardless, this has code to automatically spawn planes into the air and enter them into the competition. Including respawning when a plane blows up, so you can rack up deaths and kills over time.

This spawning code could also support (with a few other code changes) a fully automated competition system, spawning each bracket and running them, then spawning the next bracket, without having to give any input.