### PR TITLE
Resource steal

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -58,5 +58,8 @@
         [BDAPersistantSettingsField] public static bool PERFORMANCE_LOGGING = false;
         [BDAPersistantSettingsField] public static bool AUTOCATEGORIZE_PARTS = true;
         [BDAPersistantSettingsField] public static bool SHOW_CATEGORIES = false;
+        [BDAPersistantSettingsField] public static bool RESOURCE_STEAL_ENABLED = false;
+        [BDAPersistantSettingsField] public static float RESOURCE_STEAL_FUEL_RATION = 0.2f;
+        [BDAPersistantSettingsField] public static float RESOURCE_STEAL_AMMO_RATION = 0.2f;
     }
 }

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -539,15 +539,20 @@ namespace BDArmory.Bullets
                     tData.lastHitTime = Planetarium.GetUniversalTime();
                     tData.everyoneWhoHitMe.Add(aName);
 
-                    Vessel attacker = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(aName));
-                    Vessel defender = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(tName));
-                    if (attacker != null && defender != null)
+                    if (BDArmorySettings.RESOURCE_STEAL_ENABLED)
                     {
-                        StealResource(attacker, defender, "LiquidFuel", 0.5);
-                        StealResource(attacker, defender, "Oxidizer", 0.5);
-                        StealResource(attacker, defender, "20x102Ammo", 0.1);
-                        StealResource(attacker, defender, "30x173Ammo", 0.1);
-                        StealResource(attacker, defender, "50CalAmmo", 0.1);
+                        float fuelRation = BDArmorySettings.RESOURCE_STEAL_FUEL_RATION;
+                        float ammoRation = BDArmorySettings.RESOURCE_STEAL_AMMO_RATION;
+                        Vessel attacker = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(aName));
+                        Vessel defender = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(tName));
+                        if (attacker != null && defender != null)
+                        {
+                            StealResource(attacker, defender, "LiquidFuel", fuelRation);
+                            StealResource(attacker, defender, "Oxidizer", fuelRation);
+                            StealResource(attacker, defender, "20x102Ammo", ammoRation);
+                            StealResource(attacker, defender, "30x173Ammo", ammoRation);
+                            StealResource(attacker, defender, "50CalAmmo", ammoRation);
+                        }
                     }
                 }
             }

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -545,6 +545,9 @@ namespace BDArmory.Bullets
                     {
                         StealResource(attacker, defender, "LiquidFuel", 0.5);
                         StealResource(attacker, defender, "Oxidizer", 0.5);
+                        StealResource(attacker, defender, "20x102Ammo", 0.1);
+                        StealResource(attacker, defender, "30x173Ammo", 0.1);
+                        StealResource(attacker, defender, "50CalAmmo", 0.1);
                     }
                 }
             }
@@ -632,7 +635,7 @@ namespace BDArmory.Bullets
 
             if ( srcParts.Count == 0 || dstParts.Count == 0 )
             {
-                Debug.Log(string.Format("[BDArmoryCompetition] Steal resource {0} failed; no parts.", resourceName));
+                //Debug.Log(string.Format("[BDArmoryCompetition] Steal resource {0} failed; no parts.", resourceName));
                 return;
             }
 
@@ -644,21 +647,43 @@ namespace BDArmory.Bullets
             PriorityQueue recipients = new PriorityQueue(dstParts);
 
             List<ResourceAllocation> allocations = new List<ResourceAllocation>();
-            while( sources.HasNext() && recipients.HasNext() )
+            List<PartResource> inputs = null, outputs = null;
+            while ( amount > 0 )
             {
-                List<PartResource> inputs = sources.Pop();
-                List<PartResource> outputs = recipients.Pop();
+                if (inputs == null)
+                {
+                    inputs = sources.Pop();
+                }
+                if (outputs == null)
+                {
+                    outputs = recipients.Pop();
+                }
                 double availability = inputs.Sum(e => e.amount);
                 double opportunity = outputs.Sum(e => e.maxAmount - e.amount);
-                double perPartAmount = Math.Min(availability, amount) / (inputs.Count * outputs.Count);
+                double tAmount = Math.Min(availability, Math.Min(opportunity, amount));
+                double perPartAmount = tAmount / (inputs.Count * outputs.Count);
                 foreach (PartResource n in inputs)
                 {
                     foreach (PartResource m in outputs)
                     {
+                        //Debug.Log(string.Format("[BDArmoryCompetition] Allocate {0} of {1} from {2} to {3}", perPartAmount, resourceName, n.part.name, m.part.name));
                         ResourceAllocation ra = new ResourceAllocation(n, m.part, perPartAmount);
                         allocations.Add(ra);
                     }
                 }
+                if( availability < amount )
+                {
+                    inputs = null;
+                }
+                if( opportunity < amount )
+                {
+                    outputs = null;
+                }
+                if( tAmount == 0 )
+                {
+                    break;
+                }
+                amount -= tAmount;
             }
             if( allocations.Count == 0 )
             {
@@ -669,9 +694,9 @@ namespace BDArmory.Bullets
             {
                 confirmed += ra.sourceResource.part.TransferResource(ra.sourceResource, ra.amount, ra.destPart);
             }
-            if (confirmed > 0)
+            if (confirmed < 0)
             {
-                Debug.Log(string.Format("[BDArmoryCompetition] Steal completed {0} from {2} to {1}", -confirmed, src.vesselName, dst.vesselName));
+                Debug.Log(string.Format("[BDArmoryCompetition] Steal completed {0} of {3} from {2} to {1}", -confirmed, src.vesselName, dst.vesselName, resourceName));
             }
         }
 

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -538,6 +538,14 @@ namespace BDArmory.Bullets
                     tData.lastPersonWhoHitMe = aName;
                     tData.lastHitTime = Planetarium.GetUniversalTime();
                     tData.everyoneWhoHitMe.Add(aName);
+
+                    Vessel attacker = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(aName));
+                    Vessel defender = FlightGlobals.Vessels.Find(v => v.vesselName.Equals(tName));
+                    if (attacker != null && defender != null)
+                    {
+                        StealResource(attacker, defender, "LiquidFuel", 0.5);
+                        StealResource(attacker, defender, "Oxidizer", 0.5);
+                    }
                 }
             }
 
@@ -556,6 +564,89 @@ namespace BDArmory.Bullets
             {
                 hitPart.AddBallisticDamage(bulletMass, caliber, multiplier, penetrationfactor,
                     bulletDmgMult, impactVelocity);
+            }
+        }
+
+        private void StealResource(Vessel src, Vessel dst, string resourceName, double ration)
+        {
+            // identify all parts on source vessel with resource
+            HashSet<PartResource> srcParts = new HashSet<PartResource>();
+            foreach (Part p in src.Parts)
+            {
+                DeepFind(p, resourceName, srcParts);
+            }
+
+            // identify all parts on destination vessel with resource
+            HashSet<PartResource> dstParts = new HashSet<PartResource>();
+            foreach (Part p in dst.Parts)
+            {
+                DeepFind(p, resourceName, dstParts);
+            }
+
+            if ( srcParts.Count == 0 || dstParts.Count == 0 )
+            {
+                Debug.Log(string.Format("[BDArmoryCompetition] Steal resource {0} failed; no parts.", resourceName));
+                return;
+            }
+
+            double remainingAmount = srcParts.Sum(p => p.amount);
+            double amount = remainingAmount * ration;
+
+            // transfer resource from src->dst parts, distributed evenly
+            List<PartResource> orderedSrcParts = new List<PartResource>(srcParts);
+            List<PartResource> orderedDstParts = new List<PartResource>(dstParts);
+            int srcIndex = 0;
+            double srcVal = 0;
+            for (int k=0;k<orderedSrcParts.Count;k++)
+            {
+                if( orderedSrcParts[k].amount > srcVal )
+                {
+                    srcVal = orderedSrcParts[k].amount;
+                    srcIndex = k;
+                }
+            }
+            int dstIndex = 0;
+            double val = 0;
+            for (int k=0;k<orderedDstParts.Count;k++)
+            {
+                double diff = orderedDstParts[k].maxAmount - orderedDstParts[k].amount;
+                if( diff > val )
+                {
+                    val = diff;
+                    dstIndex = k;
+                }
+            }
+            PartResource pr = orderedSrcParts[srcIndex];
+            PartResource rcv = orderedDstParts[dstIndex];
+            amount = Math.Min(Math.Min(amount, pr.amount), rcv.maxAmount - rcv.amount);
+            if (amount == 0)
+            {
+                return;
+            }
+            Debug.Log(string.Format("[BDArmoryCompetition] Attempting steal {0} of {1} from {2} (curr={3},max={4}) to {5} (curr={6},max={7})", amount, resourceName, pr.part.name, pr.amount, pr.maxAmount, rcv.part.name, rcv.amount, rcv.maxAmount));
+            double confirmedAmount = pr.part.TransferResource(pr, amount, rcv.part);
+            if( confirmedAmount < 0 )
+            {
+                Debug.Log(string.Format("[BDArmoryCompetition] Steal successful {0} from {2} to {1}", -confirmedAmount, src.vesselName, dst.vesselName));
+            }
+            else
+            {
+                Debug.Log("[BDArmoryCompetition] Steal failed");
+            }
+        }
+
+        private void DeepFind(Part p, string resourceName, HashSet<PartResource> accumulator)
+        {
+            foreach (PartResource r in p.Resources)
+            {
+                if( r.resourceName.Equals(resourceName) )
+                {
+                    accumulator.Add(r);
+                }
+            }
+            foreach (Part child in p.children)
+            {
+                DeepFind(child, resourceName, accumulator);
             }
         }
 

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -567,6 +567,53 @@ namespace BDArmory.Bullets
             }
         }
 
+        private class PriorityQueue
+        {
+            private Dictionary<int, List<PartResource>> partResources = new Dictionary<int, List<PartResource>>();
+
+            public PriorityQueue(HashSet<PartResource> elements)
+            {
+                foreach (PartResource r in elements)
+                {
+                    Add(r);
+                }
+            }
+
+            public void Add(PartResource r)
+            {
+                int key = r.part.resourcePriorityOffset;
+                if( partResources.ContainsKey(key) )
+                {
+                    List<PartResource> existing = partResources[key];
+                    existing.Add(r);
+                    partResources[key] = existing;
+                }
+                else
+                {
+                    List<PartResource> newList = new List<PartResource>();
+                    newList.Add(r);
+                    partResources.Add(key, newList);
+                }
+            }
+
+            public List<PartResource> Pop()
+            {
+                if( partResources.Count == 0 )
+                {
+                    return new List<PartResource>();
+                }
+                int key = partResources.Keys.Max();
+                List<PartResource> result = partResources[key];
+                partResources.Remove(key);
+                return result;
+            }
+
+            public bool HasNext()
+            {
+                return partResources.Count != 0;
+            }
+        }
+
         private void StealResource(Vessel src, Vessel dst, string resourceName, double ration)
         {
             // identify all parts on source vessel with resource
@@ -592,46 +639,52 @@ namespace BDArmory.Bullets
             double remainingAmount = srcParts.Sum(p => p.amount);
             double amount = remainingAmount * ration;
 
-            // transfer resource from src->dst parts, distributed evenly
-            List<PartResource> orderedSrcParts = new List<PartResource>(srcParts);
-            List<PartResource> orderedDstParts = new List<PartResource>(dstParts);
-            int srcIndex = 0;
-            double srcVal = 0;
-            for (int k=0;k<orderedSrcParts.Count;k++)
+            // transfer resource from src->dst parts, honoring their priorities
+            PriorityQueue sources = new PriorityQueue(srcParts);
+            PriorityQueue recipients = new PriorityQueue(dstParts);
+
+            List<ResourceAllocation> allocations = new List<ResourceAllocation>();
+            while( sources.HasNext() && recipients.HasNext() )
             {
-                if( orderedSrcParts[k].amount > srcVal )
+                List<PartResource> inputs = sources.Pop();
+                List<PartResource> outputs = recipients.Pop();
+                double availability = inputs.Sum(e => e.amount);
+                double opportunity = outputs.Sum(e => e.maxAmount - e.amount);
+                double perPartAmount = Math.Min(availability, amount) / (inputs.Count * outputs.Count);
+                foreach (PartResource n in inputs)
                 {
-                    srcVal = orderedSrcParts[k].amount;
-                    srcIndex = k;
+                    foreach (PartResource m in outputs)
+                    {
+                        ResourceAllocation ra = new ResourceAllocation(n, m.part, perPartAmount);
+                        allocations.Add(ra);
+                    }
                 }
             }
-            int dstIndex = 0;
-            double val = 0;
-            for (int k=0;k<orderedDstParts.Count;k++)
-            {
-                double diff = orderedDstParts[k].maxAmount - orderedDstParts[k].amount;
-                if( diff > val )
-                {
-                    val = diff;
-                    dstIndex = k;
-                }
-            }
-            PartResource pr = orderedSrcParts[srcIndex];
-            PartResource rcv = orderedDstParts[dstIndex];
-            amount = Math.Min(Math.Min(amount, pr.amount), rcv.maxAmount - rcv.amount);
-            if (amount == 0)
+            if( allocations.Count == 0 )
             {
                 return;
             }
-            Debug.Log(string.Format("[BDArmoryCompetition] Attempting steal {0} of {1} from {2} (curr={3},max={4}) to {5} (curr={6},max={7})", amount, resourceName, pr.part.name, pr.amount, pr.maxAmount, rcv.part.name, rcv.amount, rcv.maxAmount));
-            double confirmedAmount = pr.part.TransferResource(pr, amount, rcv.part);
-            if( confirmedAmount < 0 )
+            double confirmed = 0;
+            foreach (ResourceAllocation ra in allocations)
             {
-                Debug.Log(string.Format("[BDArmoryCompetition] Steal successful {0} from {2} to {1}", -confirmedAmount, src.vesselName, dst.vesselName));
+                confirmed += ra.sourceResource.part.TransferResource(ra.sourceResource, ra.amount, ra.destPart);
             }
-            else
+            if (confirmed > 0)
             {
-                Debug.Log("[BDArmoryCompetition] Steal failed");
+                Debug.Log(string.Format("[BDArmoryCompetition] Steal completed {0} from {2} to {1}", -confirmed, src.vesselName, dst.vesselName));
+            }
+        }
+
+        private class ResourceAllocation
+        {
+            public PartResource sourceResource;
+            public Part destPart;
+            public double amount;
+            public ResourceAllocation(PartResource r, Part p, double a)
+            {
+                this.sourceResource = r;
+                this.destPart = p;
+                this.amount = a;
             }
         }
 

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1413,6 +1413,15 @@ namespace BDArmory.UI
             BDArmorySettings.MAX_NUM_BULLET_DECALS = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.MAX_NUM_BULLET_DECALS, 1f, 999);
             line++;
             line++;
+            BDArmorySettings.RESOURCE_STEAL_ENABLED = GUI.Toggle(SLeftRect(line), BDArmorySettings.RESOURCE_STEAL_ENABLED, Localizer.Format("#LOC_BDArmory_Settings_ResourceStealEnabled"));//"Resource Steal Enabled"
+            line++;
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_FuelStealRation")}:  ({BDArmorySettings.RESOURCE_STEAL_FUEL_RATION})", leftLabel);//Fuel Steal Ration
+            BDArmorySettings.RESOURCE_STEAL_FUEL_RATION = GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.RESOURCE_STEAL_FUEL_RATION, 0f, 1f);
+            line++;
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_AmmoStealRation")}:  ({BDArmorySettings.RESOURCE_STEAL_AMMO_RATION})", leftLabel);//Ammo Steal Ration
+            BDArmorySettings.RESOURCE_STEAL_AMMO_RATION = GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.RESOURCE_STEAL_AMMO_RATION, 0f, 1f);
+            line++;
+            line++;
 
             bool origPm = BDArmorySettings.PEACE_MODE;
             BDArmorySettings.PEACE_MODE = GUI.Toggle(SLeftRect(line), BDArmorySettings.PEACE_MODE, Localizer.Format("#LOC_BDArmory_Settings_PeaceMode"));//"Peace Mode"


### PR DESCRIPTION
This pull request focuses on the steal-on-hit mechanism for transferring resources between vessels when applying damage. Resource priority settings are respected.

Currently supported resources:
LiquidFuel, Oxidizer
50CalAmmo, 20x102Ammo, 30x173Ammo

Remaining issues:
- Adjust enable/disable via BDA settings UI.
- Adjust intensity via BDA settings UI.