### PR TITLE
Update to BDArmory for Runway Project version 1.3.4.2 in CKAN

### DIFF
--- a/BDArmory.Core/BDAPersistantSettingsField.cs
+++ b/BDArmory.Core/BDAPersistantSettingsField.cs
@@ -107,15 +107,14 @@ namespace BDArmory.Core
             }
             else if (type == typeof(Vector2d))
             {
-                char[] charsToTrim = { '(', ')' };
+                char[] charsToTrim = { '(', ')', ' ' };
                 string[] strings = value.Trim(charsToTrim).Split(',');
                 double x = double.Parse(strings[0]);
                 double y = double.Parse(strings[1]);
                 return new Vector2d(x, y);
             }
-            Debug.LogError("[BDArmory]: BDAPersistantSettingsField to parse settings field of type " + type +
-                           " and value " + value);
-
+            
+            Debug.LogError("[BDArmory]: BDAPersistantSettingsField to parse settings field of type " + type + " and value " + value);
             return null;
         }
     }

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -72,6 +72,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static int CAMERA_SWITCH_FREQUENCY = 3;               // Controls the minimum time between automated camera switches
         [BDAPersistantSettingsField] public static float OUT_OF_AMMO_KILL_TIME = -1f;            // Out of ammo kill timer for continuous spawn mode.
         [BDAPersistantSettingsField] public static bool DEBUG_RAMMING_LOGGING = false;            // Controls whether ramming logging debug information is printed to the Debug.Log
+        [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_VISIBLE = false;           // Show/hide the remote orchestration toggle
         [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_ENABLED = false;           // Enable/disable remote orchestration
         [BDAPersistantSettingsField] public static string COMPETITION_HASH = "";                  // Competition hash used for orchestration
         [BDAPersistantSettingsField] public static int COMPETITION_DURATION = 5;                  // Competition duration in minutes
@@ -82,7 +83,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static float VESSEL_SPAWN_DISTANCE = 20f;              // Scale factor for the size of the spawning circle.
         [BDAPersistantSettingsField] public static float VESSEL_SPAWN_EASE_IN_SPEED = 1f;          // Rate to limit "falling" during spawning.
         [BDAPersistantSettingsField] public static int VESSEL_SPAWN_CONCURRENT_VESSELS = 0;        // Maximum number of vessels to spawn in concurrently (continuous spawning mode).
-        [BDAPersistantSettingsField] public static int VESSEL_SPAWN_LIVES_PER_VESSEL = 0;                  // Maximum number of times to spawn a vessel (continuous spawning mode).
+        [BDAPersistantSettingsField] public static int VESSEL_SPAWN_LIVES_PER_VESSEL = 0;          // Maximum number of times to spawn a vessel (continuous spawning mode).
         [BDAPersistantSettingsField] public static bool DISABLE_KILL_TIMER = false;                //disables the kill timers.
         [BDAPersistantSettingsField] public static float REMOTE_ORCHESTRATION_WINDOW_WIDTH = 200f;
         [BDAPersistantSettingsField] public static bool RUNWAY_PROJECT = true;                    // Enable/disable Runway Project specific enhancements. FIXME Default to true for now. Later, default to false for official BDArmory release.

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -72,7 +72,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static int CAMERA_SWITCH_FREQUENCY = 3;               // Controls the minimum time between automated camera switches
         [BDAPersistantSettingsField] public static float OUT_OF_AMMO_KILL_TIME = -1f;            // Out of ammo kill timer for continuous spawn mode.
         [BDAPersistantSettingsField] public static bool DEBUG_RAMMING_LOGGING = false;            // Controls whether ramming logging debug information is printed to the Debug.Log
-        [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_VISIBLE = false;           // Show/hide the remote orchestration toggle
+        [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_VISIBLE = true;           // Show/hide the remote orchestration toggle
         [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_ENABLED = false;           // Enable/disable remote orchestration
         [BDAPersistantSettingsField] public static string COMPETITION_HASH = "";                  // Competition hash used for orchestration
         [BDAPersistantSettingsField] public static int COMPETITION_DURATION = 5;                  // Competition duration in minutes

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -81,6 +81,8 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static float VESSEL_SPAWN_ALTITUDE = 5f;               // Spawning altitude above the surface.
         [BDAPersistantSettingsField] public static float VESSEL_SPAWN_DISTANCE = 20f;              // Scale factor for the size of the spawning circle.
         [BDAPersistantSettingsField] public static float VESSEL_SPAWN_EASE_IN_SPEED = 1f;          // Rate to limit "falling" during spawning.
+        [BDAPersistantSettingsField] public static int VESSEL_SPAWN_CONCURRENT_VESSELS = 0;        // Maximum number of vessels to spawn in concurrently (continuous spawning mode).
+        [BDAPersistantSettingsField] public static int VESSEL_SPAWN_LIVES_PER_VESSEL = 0;                  // Maximum number of times to spawn a vessel (continuous spawning mode).
         [BDAPersistantSettingsField] public static bool DISABLE_KILL_TIMER = false;                //disables the kill timers.
         [BDAPersistantSettingsField] public static float REMOTE_ORCHESTRATION_WINDOW_WIDTH = 200f;
         [BDAPersistantSettingsField] public static bool RUNWAY_PROJECT = true;                    // Enable/disable Runway Project specific enhancements. FIXME Default to true for now. Later, default to false for official BDArmory release.

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -76,6 +76,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_ENABLED = false;           // Enable/disable remote orchestration
         [BDAPersistantSettingsField] public static string COMPETITION_HASH = "";                  // Competition hash used for orchestration
         [BDAPersistantSettingsField] public static int COMPETITION_DURATION = 5;                  // Competition duration in minutes
+        [BDAPersistantSettingsField] public static float COMPETITION_DISTANCE = 1000;             // Competition distance.
         [BDAPersistantSettingsField] public static float VESSEL_SWITCHER_WINDOW_WIDTH = 500f;
         [BDAPersistantSettingsField] public static bool VESSEL_SWITCHER_WINDOW_SORTING = false;
         [BDAPersistantSettingsField] public static Vector2d VESSEL_SPAWN_GEOCOORDS = new Vector2d(0.05096, -74.8016); // Spawning coordinates on a planetary body.

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -234,6 +234,7 @@
     <Compile Include="UI\IBDWMModule.cs" />
     <Compile Include="UI\KrakensbaneDebug.cs" />
     <Compile Include="UI\VesselSpawner.cs" />
+    <Compile Include="UI\VesselSpawnerField.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BDArmory.Core\BDArmory.Core.csproj">

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -544,7 +544,7 @@ namespace BDArmory.Bullets
             var aName = this.sourceVessel.GetName();
             var tName = hitPart.vessel.GetName();
 
-            if (aName != tName)
+            if (aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(aName) && BDACompetitionMode.Instance.Scores.ContainsKey(tName))
             {
                 //Debug.Log("[BDArmory]: Weapon from " + aName + " damaged " + tName);
 
@@ -555,7 +555,6 @@ namespace BDArmory.Bullets
                 }
 
                 // update scoring structure on attacker
-                if (BDACompetitionMode.Instance.Scores.ContainsKey(aName))
                 {
                     var aData = BDACompetitionMode.Instance.Scores[aName];
                     aData.Score += 1;
@@ -568,8 +567,8 @@ namespace BDArmory.Bullets
                     }
 
                 }
+
                 // update scoring structure on the defender.
-                if (BDACompetitionMode.Instance.Scores.ContainsKey(tName))
                 {
                     var tData = BDACompetitionMode.Instance.Scores[tName];
                     tData.lastPersonWhoHitMe = aName;

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -549,7 +549,10 @@ namespace BDArmory.Bullets
                 //Debug.Log("[BDArmory]: Weapon from " + aName + " damaged " + tName);
 
                 if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                {
                     BDAScoreService.Instance.TrackHit(aName, tName, bullet.name, distanceTraveled);
+                    BDAScoreService.Instance.TrackDamage(aName, tName, damage);
+                }
 
                 // update scoring structure on attacker
                 if (BDACompetitionMode.Instance.Scores.ContainsKey(aName))

--- a/BDArmory/Competition/BDAScoreClient.cs
+++ b/BDArmory/Competition/BDAScoreClient.cs
@@ -320,7 +320,10 @@ namespace BDArmory.Competition
             // load the file and modify its vessel name to match the player
             string[] lines = File.ReadAllLines(filename);
             string pattern = ".*ship = (.+)";
-            string[] modifiedLines = lines.Select(e => Regex.Replace(e, pattern, "ship = " + p.name)).ToArray();
+            string[] modifiedLines = lines
+                .Select(e => Regex.Replace(e, pattern, "ship = " + p.name))
+                .Where(e => !e.Contains("VESSELNAMING"))
+                .ToArray();
             File.WriteAllLines(filename, modifiedLines);
             Debug.Log(string.Format("[BDAScoreClient] Saved craft for player {0}", p.name));
         }

--- a/BDArmory/Competition/BDAScoreModels.cs
+++ b/BDArmory/Competition/BDAScoreModels.cs
@@ -191,6 +191,7 @@ namespace BDArmory.Competition
         public double dmg_out;
         public double dmg_in;
         public int assists;
+        public int clean_kills;
         public int kills;
         public int deaths;
         public float distance;

--- a/BDArmory/Competition/BDAScoreModels.cs
+++ b/BDArmory/Competition/BDAScoreModels.cs
@@ -186,7 +186,10 @@ namespace BDArmory.Competition
         public int competition_id;
         public int vessel_id;
         public int heat_id;
-        public int hits;
+        public int hits_out;
+        public int hits_in;
+        public double dmg_out;
+        public double dmg_in;
         public int assists;
         public int kills;
         public int deaths;

--- a/BDArmory/Competition/BDAScoreModels.cs
+++ b/BDArmory/Competition/BDAScoreModels.cs
@@ -191,7 +191,6 @@ namespace BDArmory.Competition
         public double dmg_out;
         public double dmg_in;
         public int assists;
-        public int clean_kills;
         public int kills;
         public int deaths;
         public float distance;

--- a/BDArmory/Competition/BDAScoreService.cs
+++ b/BDArmory/Competition/BDAScoreService.cs
@@ -236,8 +236,13 @@ namespace BDArmory.Competition
             // orchestrate the match
             activePlayers.Clear();
             hitsOnTarget.Clear();
+            hitsOut.Clear();
+            hitsIn.Clear();
+            damageOut.Clear();
+            damageIn.Clear();
             killsOnTarget.Clear();
             deaths.Clear();
+            assists.Clear();
             longestHitDistance.Clear();
             longestHitWeapon.Clear();
 
@@ -250,22 +255,11 @@ namespace BDArmory.Competition
                 Debug.Log("[BDAScoreService] Vessel spawning failed."); // FIXME Now what?
                 yield break;
             }
-            // if (CompetitionHub != null) // Example of how to spawn extra vessels from another folder.
-            // {
-            //     spawner.SpawnAllVesselsOnce(BDArmorySettings.VESSEL_SPAWN_GEOCOORDS, 1, false, hash+"/"+hubCraftPath);
-            //     while (spawner.vesselsSpawning)
-            //         yield return new WaitForFixedUpdate();
-            //     if (!spawner.vesselSpawnSuccess)
-            //     {
-            //         Debug.Log("[BDAScoreService] Vessel spawning failed for CompetitionHub."); // FIXME Now what?
-            //         yield break;
-            //     }
-            // }
             yield return new WaitForFixedUpdate();
 
             status = StatusType.RunningHeat;
             // NOTE: runs in separate coroutine
-            BDACompetitionMode.Instance.StartCompetitionMode(1000);
+            BDACompetitionMode.Instance.StartCompetitionMode(BDArmorySettings.COMPETITION_DISTANCE);
 
             // start timer coroutine for the duration specified in settings UI
             var duration = Core.BDArmorySettings.COMPETITION_DURATION * 60f;
@@ -285,13 +279,6 @@ namespace BDArmory.Competition
             // stop competition
             BDACompetitionMode.Instance.StopCompetition();
             BDACompetitionMode.Instance.LogResults("for BDAScoreService"); // Make sure the results are dumped to the log.
-
-            // status = StatusType.RemovingVessels;
-            // // remove all spawned vehicles // Note: Vessel and debris clean-up happens during vessel spawning (also the currently focussed vessel doesn't get killed when telling it to Die...)
-            // foreach (Vessel v in FlightGlobals.Vessels.Where(e => !e.vesselName.Equals("CompetitionHub")))
-            // {
-            //     v.Die();
-            // }
         }
 
         private IEnumerator SendScores(string hash, HeatModel heat)
@@ -462,7 +449,7 @@ namespace BDArmory.Competition
             }
             if( hitsOut.ContainsKey(attacker) )
             {
-                hitsOut[attacker]++;
+                ++hitsOut[attacker];
             }
             else
             {
@@ -470,7 +457,7 @@ namespace BDArmory.Competition
             }
             if (hitsIn.ContainsKey(target))
             {
-                hitsIn[target]++;
+                ++hitsIn[target];
             }
             else
             {

--- a/BDArmory/Competition/BDAScoreService.cs
+++ b/BDArmory/Competition/BDAScoreService.cs
@@ -238,7 +238,7 @@ namespace BDArmory.Competition
             longestHitWeapon.Clear();
 
             status = StatusType.SpawningVessels;
-            spawner.SpawnAllVesselsOnce(BDArmorySettings.VESSEL_SPAWN_GEOCOORDS, 5f, 10f, 1f, true, hash); // FIXME If geo-coords are included in the heat model, then use those instead. Also, altitude, spawn distance factor and ease-in speed.
+            spawner.SpawnAllVesselsOnce(BDArmorySettings.VESSEL_SPAWN_GEOCOORDS, BDArmorySettings.VESSEL_SPAWN_ALTITUDE, BDArmorySettings.VESSEL_SPAWN_DISTANCE, BDArmorySettings.VESSEL_SPAWN_EASE_IN_SPEED, true, hash);
             while (spawner.vesselsSpawning)
                 yield return new WaitForFixedUpdate();
             if (!spawner.vesselSpawnSuccess)

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -376,6 +376,9 @@ namespace BDArmory.Control
             GameEvents.onVesselCreate.Add(CheckVesselTypeVesselCreate);
             // GameEvents.onVesselCreate.Add(DebrisDelayedCleanUp);
             competitionStartTime = Planetarium.GetUniversalTime();
+            nextUpdateTick = competitionStartTime + 2; // 2 seconds before we start tracking
+            gracePeriod = competitionStartTime + 60;
+            decisionTick = competitionStartTime + 60; // every 60 seconds we do nasty things
             lastTagUpdateTime = competitionStartTime;
         }
 
@@ -1540,7 +1543,7 @@ namespace BDArmory.Control
                         bool shouldKillThis = false;
 
                         // if vessels is Debris, kill it
-                        if (vesselName.Contains("Debris"))
+                        if (vesselName.Contains("Debris")) // FIXME delayed debris cleanup should remove this too
                         {
                             // reap this vessel
                             shouldKillThis = true;

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -55,6 +55,7 @@ namespace BDArmory.Control
         public Dictionary<string, int> rammingPartLossCounts = new Dictionary<string, int>();
         public Dictionary<string, int> missilePartDamageCounts = new Dictionary<string, int>();
         public GMKillReason gmKillReason = GMKillReason.None;
+        public bool cleanDeath = false;
 
         public double LastDamageTime()
         {
@@ -1637,6 +1638,7 @@ namespace BDArmory.Control
                             {
                                 // if last hit was recent that person gets the kill
                                 whoKilledMe = Scores[key].LastPersonWhoDamagedMe();
+                                Scores[key].cleanDeath = true;
 
                                 var lastDamageWasFrom = Scores[key].LastDamageWasFrom();
                                 switch (lastDamageWasFrom)

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -264,6 +264,7 @@ namespace BDArmory.Control
 
         void OnDestroy()
         {
+            LogResults();
             StopCompetition();
             StopAllCoroutines();
         }
@@ -1675,7 +1676,7 @@ namespace BDArmory.Control
                                         break;
                                 }
                             }
-                            else if (Scores[key].everyoneWhoHitMe.Count > 0 || Scores[key].everyoneWhoRammedMe.Count > 0)
+                            else if (Scores[key].everyoneWhoHitMe.Count > 0 || Scores[key].everyoneWhoRammedMe.Count > 0 || Scores[key].everyoneWhoHitMeWithMissiles.Count > 0)
                             {
                                 List<string> killReasons = new List<string>();
                                 if (Scores[key].everyoneWhoHitMe.Count > 0)

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -342,7 +342,7 @@ namespace BDArmory.Control
             if (!competitionStarting)
             {
                 ResetCompetitionScores();
-                Log("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Starting Competition ");
+                Log("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Starting Competition");
                 startCompetitionNow = false;
                 competitionRoutine = StartCoroutine(DogfightCompetitionModeRoutine(distance));
             }
@@ -382,6 +382,7 @@ namespace BDArmory.Control
             gracePeriod = competitionStartTime + 60;
             decisionTick = competitionStartTime + 60; // every 60 seconds we do nasty things
             lastTagUpdateTime = competitionStartTime;
+            Log("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Competition Started");
         }
 
         IEnumerator DogfightCompetitionModeRoutine(float distance)

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1647,7 +1647,8 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":CLEANKILL:" + whoKilledMe);
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + whoKilledMe);
                                             whoCleanShotWho.Add(key, whoKilledMe);
-                                            Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
+                                            if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1657,7 +1658,8 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":CLEANMISSILEKILL:" + whoKilledMe);
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + whoKilledMe);
                                             whoCleanShotWhoWithMissiles.Add(key, whoKilledMe);
-                                            Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
+                                            if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1668,7 +1670,8 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":CLEANRAMKILL:" + whoKilledMe);
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED VIA RAMMERY BY:" + whoKilledMe);
                                             whoCleanRammedWho.Add(key, whoKilledMe);
-                                            Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
+                                            if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1691,7 +1694,8 @@ namespace BDArmory.Control
                                 {
                                     Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + killer);
                                 }
-                                Competition.BDAScoreService.Instance.TrackDeath(key);
+                                if (BDArmorySettings.REMOTE_LOGGING_ENABLED && Scores[key].gmKillReason == GMKillReason.None) // Don't count kills by the GM.
+                                    Competition.BDAScoreService.Instance.TrackKill(key, Scores[key].LastPersonWhoDamagedMe(), false);
                             }
                         }
                         if (whoKilledMe != "")
@@ -1714,6 +1718,8 @@ namespace BDArmory.Control
                             competitionStatus.Add(key + " was killed");
                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:NOBODY");
                         }
+                        if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                            Competition.BDAScoreService.Instance.TrackDeath(key);
                     }
                     doaUpdate += " :" + key + ": ";
                 }

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1648,7 +1648,7 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + whoKilledMe);
                                             whoCleanShotWho.Add(key, whoKilledMe);
                                             if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1659,7 +1659,7 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + whoKilledMe);
                                             whoCleanShotWhoWithMissiles.Add(key, whoKilledMe);
                                             if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1671,7 +1671,7 @@ namespace BDArmory.Control
                                             Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED VIA RAMMERY BY:" + whoKilledMe);
                                             whoCleanRammedWho.Add(key, whoKilledMe);
                                             if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key, true);
+                                                Competition.BDAScoreService.Instance.TrackKill(whoKilledMe, key);
                                             whoKilledMe += " (BOOM! HEADSHOT!)";
                                         }
                                         break;
@@ -1695,7 +1695,7 @@ namespace BDArmory.Control
                                     Log("[BDACompetitionMode:" + CompetitionID.ToString() + "]: " + key + ":KILLED:" + killer);
                                 }
                                 if (BDArmorySettings.REMOTE_LOGGING_ENABLED && Scores[key].gmKillReason == GMKillReason.None) // Don't count kills by the GM.
-                                    Competition.BDAScoreService.Instance.TrackKill(key, Scores[key].LastPersonWhoDamagedMe(), false);
+                                    Competition.BDAScoreService.Instance.ComputeAssists(key, "", Planetarium.GetUniversalTime() - competitionStartTime);
                             }
                         }
                         if (whoKilledMe != "")

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -288,6 +288,7 @@ namespace BDArmory.Control
             whoCleanShotWhoWithMissiles.Clear();
             whoCleanRammedWho.Clear();
             KillTimer.Clear();
+            pilotActions.Clear(); // Clear the pilotActions, so we don't get "<pilot> is Dead" on the next round of the competition.
             dumpedResults = 5;
             competitionStartTime = competitionIsActive ? Planetarium.GetUniversalTime() : -1;
             nextUpdateTick = competitionStartTime + 2; // 2 seconds before we start tracking

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -435,7 +435,7 @@ namespace BDArmory.Control
 
             foreach (var vname in Scores.Keys)
             {
-                Log("[BDACompetitionMode" + CompetitionID.ToString() + "]: Adding Score Tracker For " + vname);
+                Log("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Adding Score Tracker For " + vname);
             }
 
             if (pilots.Count < 2)
@@ -1600,7 +1600,7 @@ namespace BDArmory.Control
                 else if (pinataAlive && !alive.Contains("Pinata"))
                 {
                     // switch everyone onto separate teams when the Pinata Dies
-                    LoadedVesselSwitcher.MassTeamSwitch();
+                    LoadedVesselSwitcher.Instance.MassTeamSwitch();
                     pinataAlive = false;
                     competitionStatus.Add("Pinata is dead - competition is now a Free for all");
                     // start kill clock

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -25,9 +25,9 @@ namespace BDArmory.Control
         public int PinataHits;
         public int totalDamagedPartsDueToRamming = 0;
         public int totalDamagedPartsDueToMissiles = 0;
-        public string lastPersonWhoHitMe;
-        public string lastPersonWhoHitMeWithAMissile;
-        public string lastPersonWhoRammedMe;
+        public string lastPersonWhoHitMe = "";
+        public string lastPersonWhoHitMeWithAMissile = "";
+        public string lastPersonWhoRammedMe = "";
         public double lastHitTime; // Bullets
         public bool tagIsIt = false; // For tag mode
         public int tagKillsWhileIt = 0; // For tag mode
@@ -303,12 +303,7 @@ namespace BDArmory.Control
                     if (pilot == null || !pilot.weaponManager || pilot.weaponManager.Team.Neutral)
                         continue;
                     // put these in the scoring dictionary - these are the active participants
-                    ScoringData vDat = new ScoringData();
-                    vDat.lastPersonWhoHitMe = "";
-                    vDat.lastPersonWhoRammedMe = "";
-                    vDat.lastFiredTime = Planetarium.GetUniversalTime();
-                    vDat.previousPartCount = loadedVessels.Current.parts.Count();
-                    Scores[loadedVessels.Current.GetName()] = vDat;
+                    Scores[loadedVessels.Current.GetName()] = new ScoringData { lastFiredTime = Planetarium.GetUniversalTime(), previousPartCount = loadedVessels.Current.parts.Count };
                 }
         }
 
@@ -1980,7 +1975,8 @@ namespace BDArmory.Control
             {
                 var vessel = rammingInformation[vesselName].vessel;
                 var pilotAI = vessel?.FindPartModuleImplementing<BDModulePilotAI>(); // Get the pilot AI if the vessel has one.
-                                                                                     // Use a parallel foreach for speed. Note that we are only changing values in the dictionary, not adding or removing items, and no item is changed more than once, so this ought to be thread-safe.
+
+                // Use a parallel foreach for speed. Note that we are only changing values in the dictionary, not adding or removing items, and no item is changed more than once, so this ought to be thread-safe.
                 Parallel.ForEach<string>(rammingInformation[vesselName].targetInformation.Keys, (otherVesselName) =>
                 {
                     var otherVessel = rammingInformation[vesselName].targetInformation[otherVesselName].vessel;

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1205,6 +1205,7 @@ namespace BDArmory.Control
             var debrisToKill = new List<Vessel>();
             foreach (var vessel in FlightGlobals.Vessels)
             {
+                if (vessel.vesselType == VesselType.SpaceObject) continue; // Ignore asteroids and comets, killing them off can cause null refs (especially comets).
                 // if (vessel.vesselType == VesselType.Debris) continue; // Handled by DebrisDelayedCleanUp
                 bool activePilot = false;
                 if (BDArmorySettings.RUNWAY_PROJECT && vessel.GetName() == "Pinata")

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1771,6 +1771,7 @@ namespace BDArmory.Control
         // This now also writes the competition logs to GameData/BDArmory/Logs/<CompetitionID>[-tag].log
         public void LogResults(string message = "", string tag = "")
         {
+            competitionStatus.Add("Dumping scores for competition " + CompetitionID.ToString() + (tag != "" ? " " + tag : ""));
             if (VesselSpawner.Instance.vesselsSpawningContinuously) // Dump continuous spawning scores instead.
             {
                 VesselSpawner.Instance.DumpContinuousSpawningScores(tag);

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1771,17 +1771,18 @@ namespace BDArmory.Control
         // This now also writes the competition logs to GameData/BDArmory/Logs/<CompetitionID>[-tag].log
         public void LogResults(string message = "", string tag = "")
         {
-            competitionStatus.Add("Dumping scores for competition " + CompetitionID.ToString() + (tag != "" ? " " + tag : ""));
             if (VesselSpawner.Instance.vesselsSpawningContinuously) // Dump continuous spawning scores instead.
             {
                 VesselSpawner.Instance.DumpContinuousSpawningScores(tag);
                 return;
             }
 
+
             var logStrings = new List<string>();
 
             // get everyone who's still alive
             HashSet<string> alive = new HashSet<string>();
+            competitionStatus.Add("Dumping scores for competition " + CompetitionID.ToString() + (tag != "" ? " " + tag : ""));
             logStrings.Add("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Dumping Results" + (message != "" ? " " + message : "") + " at " + (int)(Planetarium.GetUniversalTime() - competitionStartTime) + "s");
 
 

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -74,6 +74,8 @@ Localization
 		#LOC_BDArmory_Settings_VesselSpawnGeoCoords = Set Vessel Spawn Point Here
 		#LOC_BDArmory_Settings_SpawnDistanceFactor = Spawning Distance Factor
 		#LOC_BDArmory_Settings_SpawnEaseInSpeed = Spawning Ease-In Speed
+		#LOC_BDArmory_Settings_SpawnConcurrentVessels = Concurrent Vessels (CS)
+		#LOC_BDArmory_Settings_LivesPerVessel = Lives Per Vessel (CS)
 		#LOC_BDArmory_Settings_RWRWindowScale = RWR Window Scale
 		#LOC_BDArmory_Settings_RadarWindowScale = Radar Window Scale
 		#LOC_BDArmory_Settings_TargetWindowScale = Target Window Scale

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -75,7 +75,8 @@ Localization
 		#LOC_BDArmory_Settings_SpawnDistanceFactor = Spawning Distance Factor
 		#LOC_BDArmory_Settings_SpawnEaseInSpeed = Spawning Ease-In Speed
 		#LOC_BDArmory_Settings_SpawnConcurrentVessels = Concurrent Vessels (CS)
-		#LOC_BDArmory_Settings_LivesPerVessel = Lives Per Vessel (CS)
+		#LOC_BDArmory_Settings_SpawnLivesPerVessel = Lives Per Vessel (CS)
+		#LOC_BDArmory_Settings_SpawnLocations = Interesting Spawn Locations
 		#LOC_BDArmory_Settings_RWRWindowScale = RWR Window Scale
 		#LOC_BDArmory_Settings_RadarWindowScale = Radar Window Scale
 		#LOC_BDArmory_Settings_TargetWindowScale = Target Window Scale

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BDArmory.Bullets;
+using BDArmory.Competition;
 using BDArmory.Control;
 using BDArmory.Core;
 using BDArmory.Core.Extension;
@@ -430,6 +431,7 @@ namespace BDArmory.FX
                                             tData.damageFromBullets[aName] += damage;
                                         else
                                             tData.damageFromBullets.Add(aName, damage);
+                                        BDAScoreService.Instance.TrackDamage(aName, tName, damage);
                                         break;
                                     case ExplosionSourceType.Missile:
                                         if (tData.damageFromMissiles.ContainsKey(aName))

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -431,7 +431,8 @@ namespace BDArmory.FX
                                             tData.damageFromBullets[aName] += damage;
                                         else
                                             tData.damageFromBullets.Add(aName, damage);
-                                        BDAScoreService.Instance.TrackDamage(aName, tName, damage);
+                                        if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                            BDAScoreService.Instance.TrackDamage(aName, tName, damage);
                                         break;
                                     case ExplosionSourceType.Missile:
                                         if (tData.damageFromMissiles.ContainsKey(aName))

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -901,10 +901,6 @@ namespace BDArmory.Radar
                                             break;
                                         }
                                     }
-                                    else
-                                    {
-                                        break;
-                                    }
                                 }
                             }
                             else

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1612,11 +1612,11 @@ namespace BDArmory.UI
             BDArmorySettings.VESSEL_SPAWN_EASE_IN_SPEED = Mathf.Round(GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_EASE_IN_SPEED, 0.1f, 1f) * 10f) / 10f;
             line++;
 
-            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_SpawnConcurrentVessels")}:  ({(BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS.ToString() : "inf")})", leftLabel);//Max Concurrent Vessels (CS)
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_SpawnConcurrentVessels")}:  ({(BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS.ToString() : "Inf")})", leftLabel);//Max Concurrent Vessels (CS)
             BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS, 0f, 20f);
             line++;
 
-            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_LivesPerVessel")}:  ({(BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL.ToString() : "inf")})", leftLabel);//Respawns (CS)
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_LivesPerVessel")}:  ({(BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL.ToString() : "Inf")})", leftLabel);//Respawns (CS)
             BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL, 0f, 20f);
             line++;
 

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1360,6 +1360,11 @@ namespace BDArmory.UI
             return new Rect(settingsWidth / 2 + settingsMargin / 4, line * settingsLineHeight, (settingsWidth - 2 * settingsMargin) / 2 - settingsMargin / 4, settingsLineHeight);
         }
 
+        Rect SQuarterRect(float line, int pos)
+        {
+            return new Rect(settingsMargin + (pos % 4) * (settingsWidth - 2f * settingsMargin) / 4f, (line + (int)(pos / 4)) * settingsLineHeight, (settingsWidth - 2.5f * settingsMargin) / 4f, settingsLineHeight);
+        }
+
         List<Rect> SRight2Rects(float line)
         {
             var rectGap = settingsMargin / 2;
@@ -1444,6 +1449,7 @@ namespace BDArmory.UI
         }
         Dictionary<string, SpawnField> spawnFields;
 
+        bool showSpawnLocations = false;
         void WindowSettings(int windowID)
         {
             float line = 1.25f;
@@ -1616,7 +1622,7 @@ namespace BDArmory.UI
             BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS, 0f, 20f);
             line++;
 
-            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_LivesPerVessel")}:  ({(BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL.ToString() : "Inf")})", leftLabel);//Respawns (CS)
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_SpawnLivesPerVessel")}:  ({(BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL.ToString() : "Inf")})", leftLabel);//Respawns (CS)
             BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL, 0f, 20f);
             line++;
 
@@ -1639,11 +1645,26 @@ namespace BDArmory.UI
             BDArmorySettings.VESSEL_SPAWN_GEOCOORDS.y = Math.Min(Math.Max(spawnFields["lon"].currentValue, -180), 180);
             BDArmorySettings.VESSEL_SPAWN_ALTITUDE = Math.Max(0, (float)spawnFields["alt"].currentValue);
             line++;
-
-            line++;
+            showSpawnLocations = GUI.Toggle(SLineRect(line), showSpawnLocations, (showSpawnLocations ? "Hide " : "Show ") + Localizer.Format("#LOC_BDArmory_Settings_SpawnLocations"));//Show/hide spawn locations
+            if (showSpawnLocations)
+            {
+                line++;
+                int i = 0;
+                foreach (var spawnLocation in VesselSpawner.spawnLocations)
+                {
+                    if (GUI.Button(SQuarterRect(line, i++), spawnLocation.name))
+                    {
+                        BDArmorySettings.VESSEL_SPAWN_GEOCOORDS = spawnLocation.location;
+                        spawnFields["lat"].currentValue = BDArmorySettings.VESSEL_SPAWN_GEOCOORDS.x;
+                        spawnFields["lon"].currentValue = BDArmorySettings.VESSEL_SPAWN_GEOCOORDS.y;
+                    }
+                }
+                line += (i - 1) / 4;
+            }
 
             if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.REMOTE_LOGGING_VISIBLE)
             {
+                line++;
                 bool remoteLoggingEnabled = BDArmorySettings.REMOTE_LOGGING_ENABLED;
                 BDArmorySettings.REMOTE_LOGGING_ENABLED = GUI.Toggle(SLeftRect(line), remoteLoggingEnabled, Localizer.Format("#LOC_BDArmory_Settings_RemoteLogging"));//"Remote Logging"
                 line++;
@@ -1661,6 +1682,7 @@ namespace BDArmory.UI
             else
                 BDArmorySettings.REMOTE_LOGGING_ENABLED = false;
 
+            line++;
             bool origPm = BDArmorySettings.PEACE_MODE;
             BDArmorySettings.PEACE_MODE = GUI.Toggle(SLeftRect(line), BDArmorySettings.PEACE_MODE, Localizer.Format("#LOC_BDArmory_Settings_PeaceMode"));//"Peace Mode"
             if (BDArmorySettings.PEACE_MODE && !origPm)

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1612,6 +1612,14 @@ namespace BDArmory.UI
             BDArmorySettings.VESSEL_SPAWN_EASE_IN_SPEED = Mathf.Round(GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_EASE_IN_SPEED, 0.1f, 1f) * 10f) / 10f;
             line++;
 
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_SpawnConcurrentVessels")}:  ({(BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS.ToString() : "inf")})", leftLabel);//Max Concurrent Vessels (CS)
+            BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS, 0f, 20f);
+            line++;
+
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_LivesPerVessel")}:  ({(BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL.ToString() : "inf")})", leftLabel);//Respawns (CS)
+            BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL = (int)GUI.HorizontalSlider(SRightRect(line), BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL, 0f, 20f);
+            line++;
+
             if (GUI.Button(SLeftButtonRect(line), Localizer.Format("#LOC_BDArmory_Settings_VesselSpawnGeoCoords"))) //"Vessel Spawning Location"
             {
                 Ray ray = new Ray(FlightCamera.fetch.mainCamera.transform.position, FlightCamera.fetch.mainCamera.transform.forward);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -149,7 +149,6 @@ namespace BDArmory.UI
 
 
         //competition mode
-        float competitionDist = 1000;
         string compDistGui = "1000";
 
         #region Textures
@@ -442,6 +441,7 @@ namespace BDArmory.UI
                 { "lon", gameObject.AddComponent<SpawnField>().Initialise(0, BDArmorySettings.VESSEL_SPAWN_GEOCOORDS.y, -180, 180) },
                 { "alt", gameObject.AddComponent<SpawnField>().Initialise(0, BDArmorySettings.VESSEL_SPAWN_ALTITUDE, 0) },
             };
+            compDistGui = BDArmorySettings.COMPETITION_DISTANCE.ToString();
         }
 
         private void CheckIfWindowsSettingsAreWithinScreen()
@@ -1739,7 +1739,7 @@ namespace BDArmory.UI
                     float cDist;
                     if (Single.TryParse(compDistGui, out cDist))
                     {
-                        competitionDist = cDist;
+                        BDArmorySettings.COMPETITION_DISTANCE = (int)cDist;
                     }
                     line++;
 
@@ -1751,9 +1751,9 @@ namespace BDArmory.UI
                     if (GUI.Button(SRightButtonRect(line), Localizer.Format("#LOC_BDArmory_Settings_StartCompetition")))//"Start Competition"
                     {
 
-                        competitionDist = Mathf.Max(competitionDist, 0);
-                        compDistGui = competitionDist.ToString();
-                        BDACompetitionMode.Instance.StartCompetitionMode(competitionDist);
+                        BDArmorySettings.COMPETITION_DISTANCE = Mathf.Max(BDArmorySettings.COMPETITION_DISTANCE, 0);
+                        compDistGui = BDArmorySettings.COMPETITION_DISTANCE.ToString();
+                        BDACompetitionMode.Instance.StartCompetitionMode(BDArmorySettings.COMPETITION_DISTANCE);
                         SaveConfig();
                         windowSettingsEnabled = false;
                     }
@@ -1766,7 +1766,7 @@ namespace BDArmory.UI
                             SaveConfig();
                             windowSettingsEnabled = false;
                         }
-                        if (GUI.Button(SRightRect(line), "Sync Remote"))
+                        if (BDArmorySettings.REMOTE_LOGGING_ENABLED && GUI.Button(SRightRect(line), "Sync Remote"))
                         {
                             string vesselPath = Environment.CurrentDirectory + $"/AutoSpawn";
                             if (!System.IO.Directory.Exists(vesselPath))

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1642,7 +1642,7 @@ namespace BDArmory.UI
 
             line++;
 
-            if (BDArmorySettings.RUNWAY_PROJECT)
+            if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.REMOTE_LOGGING_VISIBLE)
             {
                 bool remoteLoggingEnabled = BDArmorySettings.REMOTE_LOGGING_ENABLED;
                 BDArmorySettings.REMOTE_LOGGING_ENABLED = GUI.Toggle(SLeftRect(line), remoteLoggingEnabled, Localizer.Format("#LOC_BDArmory_Settings_RemoteLogging"));//"Remote Logging"

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -520,13 +520,13 @@ namespace BDArmory.UI
                         switch (BDACompetitionMode.Instance.Scores[key].LastDamageWasFrom())
                         {
                             case DamageFrom.Bullet:
-                                statusString += ") KILLED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe();
+                                statusString += ") KILLED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe() + (BDACompetitionMode.Instance.Scores[key].cleanDeath ? " (Head-shot!)" : ", et al.");
                                 break;
                             case DamageFrom.Missile:
-                                statusString += ") EXPLODED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe();
+                                statusString += ") EXPLODED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe() + (BDACompetitionMode.Instance.Scores[key].cleanDeath ? " (Head-shot!)" : ", et al.");
                                 break;
                             case DamageFrom.Ram:
-                                statusString += ") RAMMED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe();
+                                statusString += ") RAMMED BY " + BDACompetitionMode.Instance.Scores[key].LastPersonWhoDamagedMe() + (BDACompetitionMode.Instance.Scores[key].cleanDeath ? " (Head-shot!)" : ", et al.");
                                 break;
                             default:
                                 statusString += ")";

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -29,7 +29,6 @@ namespace BDArmory.UI
 
         private bool _ready;
         private bool _showGui;
-        private static bool _teamSwitchDirty;
         private bool _autoCameraSwitch = false;
 
         private readonly float _titleHeight = 30;
@@ -46,8 +45,6 @@ namespace BDArmory.UI
         public SortedList<string, List<MissileFire>> weaponManagers = new SortedList<string, List<MissileFire>>();
         private Dictionary<string, float> cameraScores = new Dictionary<string, float>();
 
-
-        private MissileFire _wmToSwitchTeam;
 
         // booleans to track state of buttons affecting everyone
         private bool _freeForAll = false;
@@ -262,40 +259,6 @@ namespace BDArmory.UI
                 {
                     Misc.Misc.UpdateGUIRect(new Rect(), _guiCheckIndex);
                 }
-
-                if (_teamSwitchDirty)
-                {
-
-                    if (_wmToSwitchTeam)
-                        _wmToSwitchTeam.NextTeam();
-                    else
-                    {
-                        // if no team is specified toggle between FFA and all friends
-                        // FFA button starts timer running
-                        //ResetSpeeds();
-                        _freeForAll = !_freeForAll;
-                        char T = 'A';
-                        // switch everyone to their own teams
-                        var allPilots = new List<MissileFire>();
-                        using (var teamManagers = weaponManagers.GetEnumerator())
-                            while (teamManagers.MoveNext())
-                                using (var wm = teamManagers.Current.Value.GetEnumerator())
-                                    while (wm.MoveNext())
-                                    {
-                                        if (wm.Current == null) continue;
-                                        allPilots.Add(wm.Current);
-
-                                    }
-                        foreach (var pilot in allPilots)
-                        {
-                            Debug.Log("[BDArmory]: assigning " + pilot.vessel.GetDisplayName() + " to team " + T.ToString());
-                            pilot.SetTeam(BDTeam.Get(T.ToString()));
-                            if (_freeForAll) T++;
-                        }
-                    }
-                    _teamSwitchDirty = false;
-                    _wmToSwitchTeam = null;
-                }
             }
         }
 
@@ -409,8 +372,8 @@ namespace BDArmory.UI
             if (GUI.Button(new Rect(BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _buttonHeight - _margin, 4, _buttonHeight, _buttonHeight), "T", _freeForAll ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button))
             {
                 // switch everyone onto different teams
-                _teamSwitchDirty = true;
-                _wmToSwitchTeam = null;
+                _freeForAll = !_freeForAll;
+                MassTeamSwitch(_freeForAll);
             }
 
             if (GUI.Button(new Rect(BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - _buttonHeight - _margin, 4, _buttonHeight, _buttonHeight), "X", BDArmorySetup.BDGuiSkin.button))
@@ -726,8 +689,7 @@ namespace BDArmory.UI
                 }
                 else
                 {
-                    _wmToSwitchTeam = wm;
-                    _teamSwitchDirty = true;
+                    wm.NextTeam();
                 }
             }
 
@@ -811,13 +773,15 @@ namespace BDArmory.UI
                 ForceSwitchVessel(firstVessel);
         }
 
-        public static void MassTeamSwitch(bool separateTeams = false)
+        public void MassTeamSwitch(bool separateTeams = false)
         {
-            _teamSwitchDirty = true;
-            if (separateTeams)
+            char T = 'A';
+            // switch everyone to their own teams
+            foreach (var weaponManager in weaponManagers.SelectMany(tm => tm.Value).Where(wm => wm != null).ToList()) // Get a copy in case activating stages causes the weaponManager list to change.
             {
-                Instance._wmToSwitchTeam = null;
-                Instance._freeForAll = false; // It gets toggled to true when the team switch happens.
+                Debug.Log("[BDArmory]: assigning " + weaponManager.vessel.GetDisplayName() + " to team " + T.ToString());
+                weaponManager.SetTeam(BDTeam.Get(T.ToString()));
+                if (separateTeams) T++;
             }
         }
 

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -454,7 +454,7 @@ namespace BDArmory.UI
             var spawnCount = continuousSpawningScores[vesselName].spawnCount - 1;
             if (spawnCount < 0) return; // Initial spawning after scores were reset.
             var scoreData = continuousSpawningScores[vesselName].scoreData;
-            if (BDACompetitionMode.Instance.DeathOrder.ContainsKey(vesselName))
+            if (newSpawn && BDACompetitionMode.Instance.DeathOrder.ContainsKey(vesselName))
                 BDACompetitionMode.Instance.DeathOrder.Remove(vesselName);
             if (BDACompetitionMode.Instance.Scores.ContainsKey(vesselName))
             {
@@ -505,11 +505,13 @@ namespace BDArmory.UI
 
         public void DumpContinuousSpawningScores(string tag = "")
         {
+
             var logStrings = new List<string>();
 
             if (continuousSpawningScores == null || continuousSpawningScores.Count == 0) return;
             foreach (var vesselName in continuousSpawningScores.Keys)
                 UpdateCompetitionScores(continuousSpawningScores[vesselName].vessel);
+            BDACompetitionMode.Instance.competitionStatus.Add("Dumping scores for competition " + BDACompetitionMode.Instance.CompetitionID.ToString() + (tag != "" ? " " + tag : ""));
             logStrings.Add("[VesselSpawner:" + BDACompetitionMode.Instance.CompetitionID + "]: Dumping Results at " + (int)(Planetarium.GetUniversalTime() - BDACompetitionMode.Instance.competitionStartTime) + "s");
             foreach (var vesselName in continuousSpawningScores.Keys)
             {
@@ -739,6 +741,8 @@ namespace BDArmory.UI
                         if ((BDACompetitionMode.Instance.competitionStarting || BDACompetitionMode.Instance.competitionIsActive) && !BDACompetitionMode.Instance.Scores.ContainsKey(vessel.vesselName))
                         {
                             BDACompetitionMode.Instance.Scores[vessel.vesselName] = new ScoringData { lastFiredTime = Planetarium.GetUniversalTime(), previousPartCount = vessel.parts.Count };
+                            if (!BDACompetitionMode.Instance.DeathOrder.ContainsKey(vessel.vesselName)) // Temporarily add the vessel to the DeathOrder to prevent it from being detected as newly dead until it's finished spawning.
+                                BDACompetitionMode.Instance.DeathOrder.Add(vessel.vesselName, BDACompetitionMode.Instance.DeathOrder.Count);
                         }
                         if (!vesselsToActivate.Contains(vessel))
                             vesselsToActivate.Add(vessel);

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -436,7 +436,7 @@ namespace BDArmory.UI
             else
             {
                 // Assign the vessels to their own teams.
-                LoadedVesselSwitcher.MassTeamSwitch(true);
+                LoadedVesselSwitcher.Instance.MassTeamSwitch(true);
                 LoadedVesselSwitcher.Instance.ForceSwitchVessel(spawnedVessels.First().Value.Item1); // Update the camera.
                 yield return new WaitForFixedUpdate();
             }

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -25,6 +25,11 @@ namespace BDArmory.UI
             Instance = this;
         }
 
+        void OnDestroy()
+        {
+            CancelVesselSpawn();
+        }
+
         private void OnGUI()
         {
         }

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -119,7 +119,7 @@ namespace BDArmory.UI
             if (killEverythingFirst)
             {
                 // Kill all vessels (including debris).
-                var vesselsToKill = new List<Vessel>(FlightGlobals.Vessels);
+                var vesselsToKill = FlightGlobals.Vessels.Where(v => v.vesselType != VesselType.SpaceObject).ToList();
                 foreach (var vessel in vesselsToKill)
                     RemoveVessel(vessel);
             }
@@ -610,7 +610,7 @@ namespace BDArmory.UI
             if (killEverythingFirst)
             {
                 // Kill all vessels (including debris).
-                var vesselsToKill = new List<Vessel>(FlightGlobals.Vessels);
+                var vesselsToKill = FlightGlobals.Vessels.Where(v => v.vesselType != VesselType.SpaceObject).ToList();
                 foreach (var vessel in vesselsToKill)
                     RemoveVessel(vessel);
             }

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -25,6 +25,11 @@ namespace BDArmory.UI
             Instance = this;
         }
 
+        void Start()
+        {
+            VesselSpawnerField.Load();
+        }
+
         void OnDestroy()
         {
         }

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -667,13 +667,29 @@ namespace BDArmory.UI
             var shipFacility = EditorFacility.None;
             var refDirection = Math.Abs(Vector3.Dot(Vector3.up, surfaceNormal)) < 0.9f ? Vector3.up : Vector3.forward; // Avoid that the reference direction is colinear with the local surface normal.
             var geeDirection = FlightGlobals.getGeeForceAtPosition(Vector3.zero);
-            var spawnSlots = OptimiseSpawnSlots(crafts.Count);
+            var spawnSlots = OptimiseSpawnSlots(BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? Math.Min(crafts.Count, BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS) : crafts.Count);
+            var spawnCounts = crafts.ToDictionary(c => c, c => 0);
+            var spawnQueue = new Queue<string>();
+            var craftToSpawn = new Queue<string>();
+            var duplicateCraftCounter = 0;
             while (vesselsSpawningContinuously)
             {
                 // Reacquire the spawn point as the local coordinate system may have changed (floating origin adjustments, local body rotation, etc.).
                 spawnPoint = FlightGlobals.currentMainBody.GetWorldSurfacePosition(geoCoords.x, geoCoords.y, terrainAltitude + altitude);
                 surfaceNormal = FlightGlobals.currentMainBody.GetSurfaceNVector(geoCoords.x, geoCoords.y);
-                var craftToSpawn = crafts.Where(craftURL => !craftURLToVesselName.ContainsKey(craftURL) || (activeWeaponManagersByCraftURL.ContainsKey(craftURL) && (activeWeaponManagersByCraftURL[craftURL] == null || activeWeaponManagersByCraftURL[craftURL].vessel == null))).ToList(); // Vessels that haven't been spawned yet, or have died. Note: we need to also check that the vessel isn't null as Unity makes it a fake null!
+                // Check if sliders have changed.
+                if (spawnSlots.Count != (BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? Math.Min(crafts.Count, BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS) : crafts.Count))
+                    spawnSlots = OptimiseSpawnSlots(BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? Math.Min(crafts.Count, BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS) : crafts.Count);
+                // Add any craft that hasn't been spawned or has died to the spawn queue if it isn't already in the queue. Note: we need to also check that the vessel isn't null as Unity makes it a fake null!
+                foreach (var craftURL in crafts.Where(craftURL => (BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL > 0 ? spawnCounts[craftURL] < BDArmorySettings.VESSEL_SPAWN_LIVES_PER_VESSEL : true) && !spawnQueue.Contains(craftURL) && (!craftURLToVesselName.ContainsKey(craftURL) || (activeWeaponManagersByCraftURL.ContainsKey(craftURL) && (activeWeaponManagersByCraftURL[craftURL] == null || activeWeaponManagersByCraftURL[craftURL].vessel == null)))))
+                {
+                    spawnQueue.Enqueue(craftURL);
+                    ++spawnCounts[craftURL];
+                }
+                var currentlyActive = LoadedVesselSwitcher.Instance.weaponManagers.SelectMany(tm => tm.Value).ToList().Count;
+                while (craftToSpawn.Count + vesselsToActivate.Count + currentlyActive < spawnSlots.Count && spawnQueue.Count > 0)
+                    craftToSpawn.Enqueue(spawnQueue.Dequeue());
+                Debug.Log("DEBUG currently active: " + currentlyActive + ", to spawn: " + craftToSpawn.Count + ", waiting for activation:" + vesselsToActivate.Count + ", queue length: " + spawnQueue.Count);
                 if (BDArmorySettings.DRAW_DEBUG_LABELS)
                 {
                     var missing = crafts.Where(craftURL => craftURLToVesselName.ContainsKey(craftURL) && !craftToSpawn.Contains(craftURL) && !FlightGlobals.Vessels.Where(v => v.FindPartModuleImplementing<MissileFire>() != null).Select(v => v.GetName()).ToList().Contains(craftURLToVesselName[craftURL])).ToList();
@@ -691,9 +707,9 @@ namespace BDArmory.UI
                     {
                         if (activeWeaponManagersByCraftURL.ContainsKey(craftURL))
                             activeWeaponManagersByCraftURL.Remove(craftURL);
-                        var heading = 360f * spawnSlots[continuousSpawnedVesselCount] / crafts.Count;
+                        var heading = 360f * spawnSlots[continuousSpawnedVesselCount] / spawnSlots.Count;
                         var direction = Vector3.ProjectOnPlane(Quaternion.AngleAxis(heading, surfaceNormal) * refDirection, surfaceNormal).normalized;
-                        var spawnDistance = crafts.Count > 1 ? spawnDistanceFactor + spawnDistanceFactor * crafts.Count : 0f; // If it's a single craft, spawn it at the spawn point.
+                        var spawnDistance = crafts.Count > 1 ? spawnDistanceFactor + spawnDistanceFactor * spawnSlots.Count : 0f; // If it's a single craft, spawn it at the spawn point.
                         craftSpawnPosition = spawnPoint + spawnDistance * direction;
                         FlightGlobals.currentMainBody.GetLatLonAlt(craftSpawnPosition, out craftGeoCoords.x, out craftGeoCoords.y, out craftGeoCoords.z); // Convert spawn point to geo-coords for the actual spawning function.
                         Vessel vessel = null;
@@ -716,10 +732,15 @@ namespace BDArmory.UI
                         if (!craftURLToVesselName.ContainsKey(craftURL))
                         {
                             if (craftURLToVesselName.ContainsValue(vessel.GetName())) // Avoid duplicate names.
-                                vessel.vesselName += "_" + continuousSpawnedVesselCount; // This shouldn't give duplicates as there shouldn't be more than crafts.Count craft.
+                                vessel.vesselName += "_" + (++duplicateCraftCounter);
                             craftURLToVesselName.Add(craftURL, vessel.GetName()); // Store the craftURL -> vessel name.
                         }
                         vessel.vesselName = craftURLToVesselName[craftURL]; // Assign the same (potentially modified) name to the craft each time.
+                        // If a competition is active, update the scoring structure.
+                        if ((BDACompetitionMode.Instance.competitionStarting || BDACompetitionMode.Instance.competitionIsActive) && !BDACompetitionMode.Instance.Scores.ContainsKey(vessel.vesselName))
+                        {
+                            BDACompetitionMode.Instance.Scores[vessel.vesselName] = new ScoringData { lastFiredTime = Planetarium.GetUniversalTime(), previousPartCount = vessel.parts.Count };
+                        }
                         if (!vesselsToActivate.Contains(vessel))
                             vesselsToActivate.Add(vessel);
                         if (!continuousSpawningScores.ContainsKey(vessel.GetName()))
@@ -727,10 +748,11 @@ namespace BDArmory.UI
                         continuousSpawningScores[vessel.GetName()].vessel = vessel; // Update some values in the scoring structure.
                         continuousSpawningScores[vessel.GetName()].outOfAmmoTime = 0;
                         ++continuousSpawnedVesselCount;
-                        continuousSpawnedVesselCount %= crafts.Count;
+                        continuousSpawnedVesselCount %= spawnSlots.Count;
                         Debug.Log("[VesselSpawner]: Vessel " + vessel.vesselName + " spawned!");
                         BDACompetitionMode.Instance.competitionStatus.Add("Spawned " + vessel.vesselName);
                     }
+                    craftToSpawn.Clear(); // Clear the queue since we just spawned all those vessels.
                     if (failedVessels != "")
                     {
                         message = "Some vessels failed to spawn, aborting: " + failedVessels;
@@ -822,16 +844,22 @@ namespace BDArmory.UI
                             // Update the ramming information for the new vessel.
                             if (BDACompetitionMode.Instance.rammingInformation != null)
                             {
+                                if (!BDACompetitionMode.Instance.rammingInformation.ContainsKey(vessel.GetName())) // Vessel information hasn't been added to rammingInformation datastructure yet.
+                                {
+                                    BDACompetitionMode.Instance.rammingInformation.Add(vessel.GetName(), new BDACompetitionMode.RammingInformation { vesselName = vessel.GetName(), targetInformation = new Dictionary<string, BDACompetitionMode.RammingTargetInformation>() });
+                                    foreach (var otherVesselName in BDACompetitionMode.Instance.rammingInformation.Keys)
+                                    {
+                                        if (otherVesselName == vessel.GetName()) continue;
+                                        BDACompetitionMode.Instance.rammingInformation[vessel.GetName()].targetInformation.Add(otherVesselName, new BDACompetitionMode.RammingTargetInformation { vessel = BDACompetitionMode.Instance.rammingInformation[otherVesselName].vessel });
+                                    }
+                                }
                                 BDACompetitionMode.Instance.rammingInformation[vessel.GetName()].vessel = vessel;
                                 BDACompetitionMode.Instance.rammingInformation[vessel.GetName()].partCount = vessel.parts.Count;
                                 BDACompetitionMode.Instance.rammingInformation[vessel.GetName()].radius = BDACompetitionMode.GetRadius(vessel);
-                                foreach (var vesselName in BDACompetitionMode.Instance.rammingInformation.Keys)
+                                foreach (var otherVesselName in BDACompetitionMode.Instance.rammingInformation.Keys)
                                 {
-                                    if (vesselName == vessel.GetName()) continue;
-                                    if (BDACompetitionMode.Instance.rammingInformation.ContainsKey(vesselName))
-                                    {
-                                        BDACompetitionMode.Instance.rammingInformation[vesselName].targetInformation[vessel.GetName()] = new BDACompetitionMode.RammingTargetInformation { vessel = vessel };
-                                    }
+                                    if (otherVesselName == vessel.GetName()) continue;
+                                    BDACompetitionMode.Instance.rammingInformation[otherVesselName].targetInformation[vessel.GetName()] = new BDACompetitionMode.RammingTargetInformation { vessel = vessel };
                                 }
                             }
                             vesselsToActivate.Remove(vessel);

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -516,7 +516,7 @@ namespace BDArmory.UI
                 var vesselScore = continuousSpawningScores[vesselName];
                 var scoreData = vesselScore.scoreData;
                 logStrings.Add("[VesselSpawner:" + BDACompetitionMode.Instance.CompetitionID + "]: Name:" + vesselName);
-                logStrings.Add("[VesselSpawner:" + BDACompetitionMode.Instance.CompetitionID + "]:  DEATHCOUNT:" + (vesselScore.spawnCount - 1 + (vesselsToActivate.Contains(vesselScore.vessel) ? 1 : 0))); // Account for vessels that haven't respawned yet.
+                logStrings.Add("[VesselSpawner:" + BDACompetitionMode.Instance.CompetitionID + "]:  DEATHCOUNT:" + (vesselScore.spawnCount - 1 + (vesselsToActivate.Contains(vesselScore.vessel) || !LoadedVesselSwitcher.Instance.weaponManagers.SelectMany(teamManager => teamManager.Value, (teamManager, weaponManager) => weaponManager.vessel).Contains(vesselScore.vessel) ? 1 : 0))); // Account for vessels that haven't respawned yet.
                 var whoShotMeScores = string.Join(", ", scoreData.Where(kvp => kvp.Value.hitCounts.Count > 0).Select(kvp => kvp.Key + ":" + string.Join(";", kvp.Value.hitCounts.Select(kvp2 => kvp2.Value + ":" + kvp2.Key))));
                 if (whoShotMeScores != "") logStrings.Add("[VesselSpawner:" + BDACompetitionMode.Instance.CompetitionID + "]:  WHOSHOTME:" + whoShotMeScores);
                 var whoDamagedMeWithBulletsScores = string.Join(", ", scoreData.Where(kvp => kvp.Value.damageFromBullets.Count > 0).Select(kvp => kvp.Key + ":" + string.Join(";", kvp.Value.damageFromBullets.Select(kvp2 => kvp2.Value.ToString("0.0") + ":" + kvp2.Key))));
@@ -689,7 +689,6 @@ namespace BDArmory.UI
                 var currentlyActive = LoadedVesselSwitcher.Instance.weaponManagers.SelectMany(tm => tm.Value).ToList().Count;
                 while (craftToSpawn.Count + vesselsToActivate.Count + currentlyActive < spawnSlots.Count && spawnQueue.Count > 0)
                     craftToSpawn.Enqueue(spawnQueue.Dequeue());
-                Debug.Log("DEBUG currently active: " + currentlyActive + ", to spawn: " + craftToSpawn.Count + ", waiting for activation:" + vesselsToActivate.Count + ", queue length: " + spawnQueue.Count);
                 if (BDArmorySettings.DRAW_DEBUG_LABELS)
                 {
                     var missing = crafts.Where(craftURL => craftURLToVesselName.ContainsKey(craftURL) && !craftToSpawn.Contains(craftURL) && !FlightGlobals.Vessels.Where(v => v.FindPartModuleImplementing<MissileFire>() != null).Select(v => v.GetName()).ToList().Contains(craftURLToVesselName[craftURL])).ToList();

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -258,6 +258,7 @@ namespace BDArmory.UI
                     var geeDirection = FlightGlobals.getGeeForceAtPosition(craftSpawnPosition);
                     vessel.SetRotation(Quaternion.FromToRotation(-Vector3.up, -geeDirection)); // Re-orient the vessel to the local gravity direction.
                     vessel.SetRotation(Quaternion.AngleAxis(Vector3.SignedAngle(-vessel.transform.forward, direction, -geeDirection), -geeDirection) * vessel.transform.rotation); // Re-orient the vessel to the right direction.
+                    vessel.SetRotation(Quaternion.AngleAxis(-10f, vessel.transform.right) * vessel.transform.rotation); // Tilt 10° outwards.
                 }
                 if (FlightGlobals.currentMainBody.hasSolidSurface)
                     vessel.SetPosition(craftSpawnPosition + localSurfaceNormal * (altitude + heightFromTerrain - distance)); // Put us at the specified altitude. Vessel rootpart height gets 35 added to it during spawning. We can't use vesselSize.y/2 as 'position' is not central to the vessel.
@@ -505,7 +506,6 @@ namespace BDArmory.UI
 
         public void DumpContinuousSpawningScores(string tag = "")
         {
-
             var logStrings = new List<string>();
 
             if (continuousSpawningScores == null || continuousSpawningScores.Count == 0) return;
@@ -730,6 +730,7 @@ namespace BDArmory.UI
                         vessel.ResumeStaging(); // Trigger staging to resume to get staging icons to work properly.
                         vessel.SetRotation(Quaternion.FromToRotation(-Vector3.up, -geeDirection)); // Re-orient the vessel to the local gravity direction.
                         vessel.SetRotation(Quaternion.AngleAxis(Vector3.SignedAngle(-vessel.transform.forward, direction, -geeDirection), -geeDirection) * vessel.transform.rotation); // Re-orient the vessel to the right direction.
+                        vessel.SetRotation(Quaternion.AngleAxis(-10f, vessel.transform.right) * vessel.transform.rotation); // Tilt 10° outwards.
                         if (!craftURLToVesselName.ContainsKey(craftURL))
                         {
                             if (craftURLToVesselName.ContainsValue(vessel.GetName())) // Avoid duplicate names.

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -27,7 +27,6 @@ namespace BDArmory.UI
 
         void OnDestroy()
         {
-            CancelVesselSpawn();
         }
 
         private void OnGUI()

--- a/BDArmory/UI/VesselSpawner.cs
+++ b/BDArmory/UI/VesselSpawner.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using KSP.UI.Screens;
 using UnityEngine;
 using BDArmory.Control;
@@ -16,6 +17,10 @@ namespace BDArmory.UI
     public class VesselSpawner : MonoBehaviour
     {
         public static VesselSpawner Instance;
+
+        // Interesting spawn locations on Kerbin.
+        public static string spawnLocationsCfg = "GameData/BDArmory/spawn_locations.cfg";
+        [VesselSpawnerField] public static List<SpawnLocation> spawnLocations;
 
         private string message;
         void Awake()
@@ -32,6 +37,7 @@ namespace BDArmory.UI
 
         void OnDestroy()
         {
+            VesselSpawnerField.Save();
         }
 
         private void OnGUI()

--- a/BDArmory/UI/VesselSpawnerField.cs
+++ b/BDArmory/UI/VesselSpawnerField.cs
@@ -74,7 +74,7 @@ namespace BDArmory.UI
             // Add defaults if nothing got loaded.
             if (VesselSpawner.spawnLocations.Count == 0)
             {
-                Debug.Log("DEBUG No locations found, adding defaults.");
+                Debug.Log("[VesselSpawnerField]: No locations found in config file, adding defaults.");
                 VesselSpawner.spawnLocations = defaultLocations.ToList();
             }
         }

--- a/BDArmory/UI/VesselSpawnerField.cs
+++ b/BDArmory/UI/VesselSpawnerField.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using BDArmory.Core;
+using BDArmory.UI;
+using UniLinq;
+using UnityEngine;
+
+namespace BDArmory.UI
+{
+    public class SpawnLocation
+    {
+        public string name;
+        public Vector2d location;
+
+        public SpawnLocation(string _name, Vector2d _location) { name = _name; location = _location; }
+        public override string ToString() { return name + ", " + location.ToString("G6"); }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class VesselSpawnerField : Attribute
+    {
+        public VesselSpawnerField()
+        {
+        }
+
+        static List<SpawnLocation> defaultLocations = new List<SpawnLocation>{
+            new SpawnLocation("KSC", new Vector2d(0.07, -74.67)),
+            new SpawnLocation("Inland KSC", new Vector2d(20.657, -146.421)),
+            new SpawnLocation("Ice field", new Vector2d(80.0821, -81.1997)),
+            new SpawnLocation("Canyon", new Vector2d(-52.67, -4.67)),
+            new SpawnLocation("Bowl 1", new Vector2d(35.6559, -77.4941)),
+            new SpawnLocation("Bowl 2", new Vector2d(3.85, -78.0)),
+            new SpawnLocation("Bowl 3", new Vector2d(0.25, -80.5)),
+            new SpawnLocation("Bowl 4", new Vector2d(6.925, -170.705)),
+            new SpawnLocation("Kurgan's spot", new Vector2d(-28.4595, -9.15156)),
+            new SpawnLocation("Half-pipe", new Vector2d(-21.10, 72.70)),
+        };
+
+        public static void Save()
+        {
+            ConfigNode fileNode = ConfigNode.Load(VesselSpawner.spawnLocationsCfg);
+            if (fileNode == null)
+                fileNode = new ConfigNode();
+
+            if (!fileNode.HasNode("BDASpawnLocations"))
+                fileNode.AddNode("BDASpawnLocations");
+
+            ConfigNode settings = fileNode.GetNode("BDASpawnLocations");
+
+            settings.ClearValues();
+            foreach (var spawnLocation in VesselSpawner.spawnLocations)
+                settings.AddValue("LOCATION", spawnLocation.ToString());
+
+            fileNode.Save(VesselSpawner.spawnLocationsCfg);
+        }
+
+        public static void Load()
+        {
+            VesselSpawner.spawnLocations = new List<SpawnLocation>();
+            ConfigNode fileNode = ConfigNode.Load(VesselSpawner.spawnLocationsCfg);
+            if (fileNode != null && fileNode.HasNode("BDASpawnLocations"))
+            {
+                ConfigNode settings = fileNode.GetNode("BDASpawnLocations");
+                foreach (var spawnLocation in settings.GetValues("LOCATION"))
+                {
+                    var parsedValue = (SpawnLocation)ParseValue(typeof(SpawnLocation), spawnLocation);
+                    if (parsedValue != null)
+                    {
+                        VesselSpawner.spawnLocations.Add(parsedValue);
+                    }
+                }
+            }
+            // Add defaults if nothing got loaded.
+            if (VesselSpawner.spawnLocations.Count == 0)
+            {
+                Debug.Log("DEBUG No locations found, adding defaults.");
+                VesselSpawner.spawnLocations = defaultLocations.ToList();
+            }
+        }
+
+        public static object ParseValue(Type type, string value)
+        {
+            try
+            {
+                if (type == typeof(string))
+                {
+                    return value;
+                }
+                else if (type == typeof(Vector2d))
+                {
+                    char[] charsToTrim = { '(', ')', ' ' };
+                    string[] strings = value.Trim(charsToTrim).Split(',');
+                    if (strings.Length == 2)
+                    {
+                        double x = double.Parse(strings[0]);
+                        double y = double.Parse(strings[1]);
+                        return new Vector2d(x, y);
+                    }
+                }
+                else if (type == typeof(SpawnLocation))
+                {
+                    var parts = value.Split(new char[] { ',' }, 2);
+                    if (parts.Length == 2)
+                    {
+                        var name = (string)ParseValue(typeof(string), parts[0]);
+                        var location = (Vector2d)ParseValue(typeof(Vector2d), parts[1]);
+                        if (name != null && location != null)
+                            return new SpawnLocation(name, location);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            Debug.LogError("[VesselSpawnerField]: Failed to parse settings field of type " + type + " and value " + value);
+            return null;
+        }
+    }
+}

--- a/BDArmory/UI/VesselSpawnerField.cs
+++ b/BDArmory/UI/VesselSpawnerField.cs
@@ -20,21 +20,21 @@ namespace BDArmory.UI
     [AttributeUsage(AttributeTargets.Field)]
     public class VesselSpawnerField : Attribute
     {
-        public VesselSpawnerField()
-        {
-        }
+        public VesselSpawnerField() { }
 
         static List<SpawnLocation> defaultLocations = new List<SpawnLocation>{
-            new SpawnLocation("KSC", new Vector2d(0.07, -74.67)),
-            new SpawnLocation("Inland KSC", new Vector2d(20.657, -146.421)),
-            new SpawnLocation("Ice field", new Vector2d(80.0821, -81.1997)),
-            new SpawnLocation("Canyon", new Vector2d(-52.67, -4.67)),
-            new SpawnLocation("Bowl 1", new Vector2d(35.6559, -77.4941)),
-            new SpawnLocation("Bowl 2", new Vector2d(3.85, -78.0)),
-            new SpawnLocation("Bowl 3", new Vector2d(0.25, -80.5)),
-            new SpawnLocation("Bowl 4", new Vector2d(6.925, -170.705)),
+            new SpawnLocation("KSC", new Vector2d(-0.04762, -74.8593)),
+            new SpawnLocation("Inland KSC", new Vector2d(20.5939, -146.567)),
+            new SpawnLocation("Desert Runway", new Vector2d(-6.44958, -144.038)),
+            new SpawnLocation("Ice field", new Vector2d(80.3343, -32.0119)),
+            new SpawnLocation("Canyon", new Vector2d(-52.7592, -4.71081)),
+            new SpawnLocation("Big Canyon", new Vector2d(6.97865, -170.804)),
+            new SpawnLocation("Manley Valley", new Vector2d(45.6, -137.3)),
+            new SpawnLocation("Half-pipe", new Vector2d(-21.1388, 72.6437)),
             new SpawnLocation("Kurgan's spot", new Vector2d(-28.4595, -9.15156)),
-            new SpawnLocation("Half-pipe", new Vector2d(-21.10, 72.70)),
+            new SpawnLocation("Bowl 1", new Vector2d(35.6559, -77.4941)),
+            new SpawnLocation("Bowl 2", new Vector2d(3.8744, -78.0039)),
+            new SpawnLocation("Bowl 3", new Vector2d(0.268284, -80.5195)),
         };
 
         public static void Save()


### PR DESCRIPTION
- Adjust vessel switcher window's display of dead vessels to reflect clean kills vs regular ones.           
- Only count clean kills as kill, give assists to all vessels with hits for regular kills.
- Support scoring for hits and damage in/out.
- Interesting Vessel Spawn locations with separate cfg file (spawn_locations.cfg).
- Fix craft not responding to multiple missile threats.
- Trigger result logging on scene change from BDACompetitionMode. Missing condition for regular kills with missiles.
- Store the competition distance.                                                  
- Automatically dump scores when leaving flight mode.
- Extra setting REMOTE_LOGGING_VISIBLE in the settings.cfg file only to hide the remote orchestration from the settings window. Defaults to ~False~ True for Scott.
- Start tilted 10° outwards when spawning in the air.
- Clear the pilotActions dictionary to avoid '<pilot> is Dead' when starting a new competition with previously used pilots.
- Adjust DeathOrder for continuous spawn to avoid '<vessel> killed by <vessel>' messages on spawning.                                              
- In-game messages when dumping competition logs.
- Fix death counts in logged scores for vessels that have run out of lives.
- Rolling spawning (sliders for controlling the maximum number of craft and the number of lives they have for continuous spawning).
- Don't clean up SpaceObjects in RemoveDebris as it is a source of null refs in the base game.
- Use user-set altitude and other settings for remote orchestration spawning.
