### PR TITLE
Important bugfix for ramming target selection for Round 3

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
@@ -12,13 +12,13 @@
     {
         "MAJOR":1,
         "MINOR":3,
-        "PATCH":4,
-        "BUILD":0
+        "PATCH":6,
+        "BUILD":5
     },
     "KSP_VERSION":
     {
         "MAJOR":1,
-        "MINOR":9,
+        "MINOR":10,
         "PATCH":1
     },
     "KSP_VERSION_MIN":
@@ -30,7 +30,7 @@
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
-        "MINOR":9,
+        "MINOR":10,
         "PATCH":999
     }
 }

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -201,6 +201,7 @@ Localization
 		#LOC_BDArmory_TargetPriority_TargetAcceleration = Target Acceleration
 		#LOC_BDArmory_TargetPriority_ShorterClosingTime = Shorter Closing Time
 		#LOC_BDArmory_TargetPriority_TargetWeaponNumber = Target Weapon Number
+		#LOC_BDArmory_TargetPriority_TargetMass = Target Mass
 		#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging = Fewer Teammates Engaging
 		#LOC_BDArmory_TargetPriority_TargetThreat = Target Threat
 		#LOC_BDArmory_TargetPriority_AngleOverDistance = Angle / Distance

--- a/BDArmory/Modules/BDExplosivePart.cs
+++ b/BDArmory/Modules/BDExplosivePart.cs
@@ -345,7 +345,7 @@ namespace BDArmory.Modules
                     if (detonateAtMinimumDistance)
                     {
                         var distance = Vector3.Distance(partHit.transform.position + partHit.CoMOffset, transform.position);
-                        var predictedDistance = Vector3.Distance(AIUtils.PredictPosition(partHit.transform.position + partHit.CoMOffset, partHit.vessel.Velocity(), partHit.vessel.acceleration, Time.deltaTime), AIUtils.PredictPosition(transform.position, vessel.Velocity(), vessel.acceleration, Time.deltaTime));
+                        var predictedDistance = Vector3.Distance(AIUtils.PredictPosition(partHit.transform.position + partHit.CoMOffset, partHit.vessel.Velocity(), partHit.vessel.acceleration, Time.fixedDeltaTime), AIUtils.PredictPosition(transform.position, vessel.Velocity(), vessel.acceleration, Time.fixedDeltaTime));
                         if (distance > predictedDistance && distance > Time.fixedDeltaTime * (float)vessel.srfSpeed) // If we're closing and not going to hit within the next update, then wait.
                         {
                             return detonate = false;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3094,6 +3094,17 @@ namespace BDArmory.Modules
                         }
                         return;
                     }
+                    else if (!BDArmorySettings.DISABLE_RAMMING)
+                    {
+                        if (!HasWeaponsAndAmmo() && pilotAI != null && pilotAI.allowRamming)
+                        {
+                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                            {
+                                Debug.Log("[MissileFire]: " + vessel.vesselName + targetDebugText + "ramming.");
+                            }
+                            return;
+                        }
+                    }
                 }
             }
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -440,6 +440,11 @@ namespace BDArmory.Modules
          UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
         public float targetWeightWeaponNumber = 0;
 
+        private string targetMassLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_TargetMass");
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetMass", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Target Mass
+         UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
+        public float targetWeightMass = 0;
+
         private string targetFriendliesEngagingLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging");
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Number Friendlies Engaging
          UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
@@ -3301,6 +3306,7 @@ namespace BDArmory.Modules
             var TargetAccelFields = Fields["targetWeightAccel"];
             var TargetClosureTimeFields = Fields["targetWeightClosureTime"];
             var TargetWeaponNumberFields = Fields["targetWeightWeaponNumber"];
+            var TargetMassFields = Fields["targetWeighMass"];
             var TargetFriendliesEngagingFields = Fields["targetWeightFriendliesEngaging"];
             var TargetThreatFields = Fields["targetWeightThreat"];
 
@@ -3312,6 +3318,7 @@ namespace BDArmory.Modules
             float targetAccelValue = target.TargetPriAcceleration();
             float targetClosureTimeValue = target.TargetPriClosureTime(this);
             float targetWeaponNumberValue = target.TargetPriWeapons(target.weaponManager, this);
+            float targetMassValue = target.TargetPriMass(target.weaponManager, this);
             float targetFriendliesEngagingValue = target.TargetPriFriendliesEngaging(this);
             float targetThreatValue = target.TargetPriThreat(target.weaponManager, this);
 
@@ -3322,6 +3329,7 @@ namespace BDArmory.Modules
                 targetWeightAccel * targetAccelValue +
                 targetWeightClosureTime * targetClosureTimeValue +
                 targetWeightWeaponNumber * targetWeaponNumberValue +
+                targetWeightMass * targetMassValue +
                 targetWeightFriendliesEngaging * targetFriendliesEngagingValue +
                 targetWeightThreat * targetThreatValue +
                 targetWeightAoD * targetAoDValue);
@@ -3334,6 +3342,7 @@ namespace BDArmory.Modules
             TargetAccelFields.guiName = targetAccelLabel + ": " + targetAccelValue.ToString("0.00");
             TargetClosureTimeFields.guiName = targetClosureTimeLabel + ": " + targetClosureTimeValue.ToString("0.00");
             TargetWeaponNumberFields.guiName = targetWeaponNumberLabel + ": " + targetWeaponNumberValue.ToString("0.00");
+            TargetMassFields.guiName = targetMassLabel + ": " + targetMassValue.ToString("0.00");
             TargetFriendliesEngagingFields.guiName = targetFriendliesEngagingLabel + ": " + targetFriendliesEngagingValue.ToString("0.00");
             TargetThreatFields.guiName = targetThreatLabel + ": " + targetThreatValue.ToString("0.00");
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3306,7 +3306,7 @@ namespace BDArmory.Modules
             var TargetAccelFields = Fields["targetWeightAccel"];
             var TargetClosureTimeFields = Fields["targetWeightClosureTime"];
             var TargetWeaponNumberFields = Fields["targetWeightWeaponNumber"];
-            var TargetMassFields = Fields["targetWeighMass"];
+            var TargetMassFields = Fields["targetWeightMass"];
             var TargetFriendliesEngagingFields = Fields["targetWeightFriendliesEngaging"];
             var TargetThreatFields = Fields["targetWeightThreat"];
 

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -353,6 +353,20 @@ namespace BDArmory.Targeting
             float theta = Vector3.Angle(myMF.vessel.srf_vel_direction, relativePosition);
             return Mathf.Clamp(((Mathf.Pow(Mathf.Cos(theta / 2f), 2f) + 1f) * 100f / Mathf.Max(10f, relativePosition.magnitude))/2, 0, 1); // Ranges from 0 to 1, clamped at 1 for distances closer than 100m
         }
+
+        public float TargetPriMass(MissileFire mf, MissileFire myMf) // Relative mass compared to our own mass
+        {
+            if (mf.vessel != null)
+            {
+                float targetMass = mf.vessel.GetTotalMass();
+                float myMass = myMf.vessel.GetTotalMass();
+                return Mathf.Clamp((targetMass - myMass) / myMass, -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+            }
+            else
+            {
+                return 0;
+            }
+        }
         // End functions used for prioritizing targets
         #endregion
 

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -360,7 +360,7 @@ namespace BDArmory.Targeting
             {
                 float targetMass = mf.vessel.GetTotalMass();
                 float myMass = myMf.vessel.GetTotalMass();
-                return Mathf.Clamp(Mathf.Log10(targetMass / myMass), -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+                return Mathf.Clamp(Mathf.Log10(targetMass / myMass)/2f, -1, 1); // Ranges -1 to 1, -1 if we are 100 times as heavy as target, 1 target is 100 times as heavy as us
             }
             else
             {

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -360,7 +360,7 @@ namespace BDArmory.Targeting
             {
                 float targetMass = mf.vessel.GetTotalMass();
                 float myMass = myMf.vessel.GetTotalMass();
-                return Mathf.Clamp((targetMass - myMass) / myMass, -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+                return Mathf.Clamp(Mathf.Log10(targetMass / myMass), -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
             }
             else
             {

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -971,6 +971,7 @@ namespace BDArmory.UI
                             mf.targetWeightAccel * target.Current.TargetPriAcceleration() +
                             mf.targetWeightClosureTime * target.Current.TargetPriClosureTime(mf) +
                             mf.targetWeightWeaponNumber * target.Current.TargetPriWeapons(target.Current.weaponManager, mf) +
+                            mf.targetWeightMass * target.Current.TargetPriMass(target.Current.weaponManager, mf) +
                             mf.targetWeightFriendliesEngaging * target.Current.TargetPriFriendliesEngaging(mf) +
                             mf.targetWeightThreat * target.Current.TargetPriThreat(target.Current.weaponManager, mf) +
                             mf.targetWeightAoD * target.Current.TargetPriAoD(mf));

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -728,7 +728,7 @@ namespace BDArmory.UI
                 if (GUI.Button(new Rect(toolWindowWidth - _windowMargin - 3 * _buttonSize, _windowMargin, _buttonSize, _buttonSize), "Sp", vsStyle))
                 {
                     showVesselSpawnerGUI = !showVesselSpawnerGUI;
-                    if(!showVesselSpawnerGUI)
+                    if (!showVesselSpawnerGUI)
                         SaveConfig();
                 }
             }
@@ -770,10 +770,7 @@ namespace BDArmory.UI
                 GUIStyle teamButtonStyle = BDGuiSkin.box;
                 string teamText = $"{Localizer.Format("#LOC_BDArmory_WMWindow_TeamText")}: {ActiveWeaponManager.Team.Name}";//Team
 
-                if (
-                    GUI.Button(
-                        new Rect(leftIndent + (contentWidth / 2), contentTop + (line * entryHeight), contentWidth / 2,
-                            entryHeight), teamText, teamButtonStyle))
+                if (GUI.Button(new Rect(leftIndent + (contentWidth / 2), contentTop + (line * entryHeight), contentWidth / 2, entryHeight), teamText, teamButtonStyle))
                 {
                     if (Event.current.button == 1)
                     {
@@ -1206,7 +1203,10 @@ namespace BDArmory.UI
             }
 
             toolWindowHeight = Mathf.Lerp(toolWindowHeight, contentTop + (line * entryHeight) + 5, 1);
+            var previousWindowHeight = WindowRectToolbar.height;
             WindowRectToolbar.height = toolWindowHeight;
+            if (BDArmorySettings.STRICT_WINDOW_BOUNDARIES && toolWindowHeight < previousWindowHeight && Mathf.Round(WindowRectToolbar.y + previousWindowHeight) == Screen.height) // Window shrunk while being at edge of screen.
+                WindowRectToolbar.y = Screen.height - WindowRectToolbar.height;
             BDGUIUtils.RepositionWindow(ref WindowRectToolbar);
         }
 

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -405,7 +405,7 @@ namespace BDArmory.UI
                 }
             }
             else // Regular sorting.
-                foreach (var teamManagers in weaponManagers)
+                foreach (var teamManagers in weaponManagers.ToList()) // Use a copy as something seems to be modifying the list occassionally.
                 {
                     height += _margin;
                     foreach (var weaponManager in teamManagers.Value)


### PR DESCRIPTION
- IMPORTANT BUGFIX FOR THIS ROUND: Allow target priority to apply to flying vessels in ramming mode.
- Keep BDAToolBar on the bottom of the screen when shrinking if it was already there.
- Extra target priority setting based on relative vessel mass.
- Bugfixes.